### PR TITLE
Update device-enrollment-program-enroll-ios.md

### DIFF
--- a/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
+++ b/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
@@ -285,7 +285,8 @@ See [Enroll your iOS/iPadOS device in Intune with the Device Enrollment Program]
 
 ## Renew a DEP token  
 
-Add a note here  - Please keep in mind that in addition to yearly refreshes, you will need to refresh your enrollment program token within Intune and Apple Business Manager when the Managed Apple ID password of the user in Apple business Manager who set up the token changes or that user leaves your Apple Business Manager organization.
+> [!NOTE]
+> In addition to renewing your DEP token yearly, you will need to renew your enrollment program token within Intune and Apple Business Manager when the Managed Apple ID password changes for the user who set up the token in Apple business Manager or that user leaves your Apple Business Manager organization.
 
 1. Go to deploy.apple.com.  
 2. Under **Manage Servers**, choose your MDM server associated with the token file that you want to renew.

--- a/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
+++ b/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
@@ -284,6 +284,9 @@ You have enabled management and syncing between Apple and Intune, and assigned a
 See [Enroll your iOS/iPadOS device in Intune with the Device Enrollment Program](../user-help/enroll-your-device-dep-ios.md).
 
 ## Renew a DEP token  
+
+Add a note here  - Please keep in mind that in addition to yearly refreshes, you will need to refresh your enrollment program token within Intune and Apple Business Manager when the Managed Apple ID password of the user in Apple business Manager who set up the token changes or that user leaves your Apple Business Manager organization.
+
 1. Go to deploy.apple.com.  
 2. Under **Manage Servers**, choose your MDM server associated with the token file that you want to renew.
 3. Choose **Generate New Token**.


### PR DESCRIPTION
We should add a note based off of new documentation that Jack Poehlman brought up. 
Based on this documentation from Apple - https://support.apple.com/guide/apple-business-manager/edit-mdm-servers-asm54ab8fff2/web

A user with the proper privileges may sometimes need to edit MDM server information. For example, a user must replace the active server token on an MDM server in these situations:
•	When a new public key is created or if a new server token is generated
•	When the Managed Apple ID password of the user who downloaded the initial token is changed
•	As a security measure, when the user who downloaded the original token leaves your organization