### PR TITLE
Clarification about the CA grant controls for domain joined PCs

### DIFF
--- a/memdocs/intune/protect/conditional-access-intune-common-ways-use.md
+++ b/memdocs/intune/protect/conditional-access-intune-common-ways-use.md
@@ -88,7 +88,7 @@ Conditional access for PCs provides capabilities similar to those available for 
 
 #### Corporate-owned
 
-- **On premises AD domain joined:** This option is commonly used by organizations that are reasonably comfortable with how they're already managing their PCs through AD group policies or Configuration Manager.
+- **Hybrid Azure AD joined:** This option is commonly used by organizations that are reasonably comfortable with how they're already managing their PCs through AD group policies or Configuration Manager.
 
 - **Azure AD domain joined and Intune management:** This scenario is for organizations that want to be cloud-first (that is, primarily use cloud services, with a goal to reduce use of an on-premises infrastructure) or cloud-only (no on-premises infrastructure). Azure AD Join works well in a hybrid environment, enabling access to both cloud and on-premises apps and resources. The device joins to the Azure AD and gets enrolled to Intune, which can be used as a conditional access criteria when accessing corporate resources.
 


### PR DESCRIPTION
Instead of just saying domain joined, we really need to say Hybrid Azure AD joined. That's the option in the CA policy settings themselves and also the only way Azure AD would know about those on-premises PCs in order to apply conditional access to them.