### PR TITLE
Need more prescriptive guidance about Defender AV exclusions

### DIFF
--- a/memdocs/intune/configuration/device-restrictions-windows-10.md
+++ b/memdocs/intune/configuration/device-restrictions-windows-10.md
@@ -902,6 +902,10 @@ These settings use the [defender policy CSP](https://docs.microsoft.com/windows/
   [Defender/ThreatSeverityDefaultAction CSP](https://docs.microsoft.com/windows/client-management/mdm/policy-csp-defender#defender-threatseveritydefaultaction)
 
 ### Microsoft Defender Antivirus Exclusions
+You can exclude certain files from Windows Defender Antivirus scans by modifying exclusion lists. **Generally, you shouldn't need to apply exclusions**. Windows Defender Antivirus includes a number of automatic exclusions based on known operating system behaviors and typical management files, such as those used in enterprise management, database management, and other enterprise scenarios and situations.
+
+> [!WARNING]
+> **Defining exclusions lowers the protection offered by Windows Defender Antivirus**. You should always evaluate the risks that are associated with implementing exclusions, and you should only exclude files that you are confident are not malicious.
 
 - **Files and folders to exclude from scans and real-time protection**: Adds one or more files and folders like **C:\Path** or **%ProgramFiles%\Path\filename.exe** to the exclusions list. These files and folders aren't included in any real-time or scheduled scans.
 - **File extensions to exclude from scans and real-time protection**: Add one or more file extensions like **jpg** or **txt** to the exclusions list. Any files with these extensions aren't included in any real-time or scheduled scans.


### PR DESCRIPTION
It's not necessary to add exclusions for Defender AV for greenfield management of Windows 10 with Intune, but we don't say that anywhere like we do for the Server OS's. Adding this content (from those other docs) to the Intune content to make it more explicit.