### PR TITLE
PowerShell to get CMG MP name contains an extra char

### DIFF
--- a/memdocs/configmgr/core/clients/deploy/about-client-installation-properties.md
+++ b/memdocs/configmgr/core/clients/deploy/about-client-installation-properties.md
@@ -104,7 +104,7 @@ This parameter can also specify the URL of a cloud management gateway (CMG). Use
 - Run the following command:
 
     ```PowerShell
-    (Get-WmiObject -Namespace Root\Ccm\LocationServices -Class SMS_ActiveMPCandidate | Where-Object {$_.Type -eq "Internet"}).MP`
+    (Get-WmiObject -Namespace Root\Ccm\LocationServices -Class SMS_ActiveMPCandidate | Where-Object {$_.Type -eq "Internet"}).MP
     ```
 
 - Append the `https://` prefix to use with the **/mp** parameter.


### PR DESCRIPTION
PowerShell query to get CMG MP name contains an extra ` char. I removed it.

If you copy the PowerShell query, it doesn't work:

(Get-WmiObject -Namespace Root\Ccm\LocationServices -Class SMS_ActiveMPCandidate | Where-Object {$_.Type -eq "Internet"}).MP`

Notice the last char.