### PR TITLE
Update system library dependency list of iOS MAM

### DIFF
--- a/memdocs/intune/developer/app-sdk-ios.md
+++ b/memdocs/intune/developer/app-sdk-ios.md
@@ -126,7 +126,7 @@ To enable the Intune App SDK, follow these steps:
 2. Add these iOS frameworks to the project:  
 -  MessageUI.framework  
 -  Security.framework  
--  MobileCoreServices.framework  
+-  CoreServices.framework  
 -  SystemConfiguration.framework  
 -  libsqlite3.tbd  
 -  libc++.tbd  


### PR DESCRIPTION
Apple has renamed MobileCoreServices.framework to CoreServices.framework. Updating the doc to reflect that.