### PR TITLE
Update licenses.md for M365 Rebrand

### DIFF
--- a/memdocs/intune/fundamentals/licenses.md
+++ b/memdocs/intune/fundamentals/licenses.md
@@ -38,7 +38,7 @@ Intune is included in the following licenses:
 - Microsoft 365 E3
 - Enterprise Mobility + Security E5
 - Enterprise Mobility + Security E3
-- Microsoft 365 Business
+- Microsoft 365 Business Premium
 - Microsoft 365 F1
 - Microsoft 365 F3
 - Microsoft 365 Government G5


### PR DESCRIPTION
Since April 21st, Microsoft 365 Business has been renamed Microsoft 365 Business Premium.

This should alleviate confusion for owners of Microsoft 365 Business Standard licenses.