### PR TITLE
Updated to use endpoint.microsoft.com

### DIFF
--- a/memdocs/configmgr/comanage/how-to-prepare-Win10.md
+++ b/memdocs/configmgr/comanage/how-to-prepare-Win10.md
@@ -100,7 +100,7 @@ For more information, see [Client installation properties](../core/clients/deplo
 
 ### Create the app in Intune
 
-1. Go to the [Microsoft Endpoint Manager admin center](https://endpoint.microsoft.com), and then expand the left nav pane.  
+1. Go to the [Microsoft Endpoint Manager admin center](https://endpoint.microsoft.com), and then expand the left navigation pane.  
 
 2. Select **Apps** > **All Apps** > **Add**.  
 

--- a/memdocs/configmgr/comanage/how-to-prepare-Win10.md
+++ b/memdocs/configmgr/comanage/how-to-prepare-Win10.md
@@ -100,9 +100,9 @@ For more information, see [Client installation properties](../core/clients/deplo
 
 ### Create the app in Intune
 
-1. Go to the [Azure portal](https://portal.azure.com), and then open the Intune page.  
+1. Go to the [Microsoft Endpoint Manager admin center](https://endpoint.microsoft.com), and then expand the left nav pane.  
 
-2. Select **Client Apps** > **Apps** > **Add**.  
+2. Select **Apps** > **All Apps** > **Add**.  
 
 3. Under **Other**, select **Line-of-business app**.  
 

--- a/memdocs/configmgr/comanage/how-to-prepare-Win10.md
+++ b/memdocs/configmgr/comanage/how-to-prepare-Win10.md
@@ -5,7 +5,7 @@ description: Learn how to prepare your Windows 10 internet-based devices for co-
 author: mestew
 ms.author: mstewart
 manager: dougeby
-ms.date: 04/24/2020
+ms.date: 05/14/2020
 ms.topic: conceptual
 ms.prod: configuration-manager
 ms.technology: configmgr-comanage

--- a/memdocs/configmgr/comanage/tutorial-co-manage-new-devices.md
+++ b/memdocs/configmgr/comanage/tutorial-co-manage-new-devices.md
@@ -5,7 +5,7 @@ description: Learn how to configure co-management for new internet-based Windows
 author: mestew
 ms.author: mstewart
 manager: dougeby
-ms.date: 03/12/2020
+ms.date: 05/14/2020
 ms.topic: tutorial
 ms.prod: configuration-manager
 ms.technology: configmgr-comanage
@@ -378,11 +378,11 @@ Then, when a previously unmanaged Windows 10 device enrolls with Intune, it auto
 
 ### Create an Intune app to install the Configuration Manager client
 
-1. From the primary site server, sign in to the [Azure portal](https://portal.azure.com/) and go to the **Intune > Client apps > Apps > Add**.
+1. From the primary site server, sign in to the [Microsoft Endpoint Manager admin center](https://endpoint.microsoft.com) and go to the **Apps** > **All Apps** > **Add**.
 
-2. For **App type**: Select **Line-of-business app**.
+2. For app type, select **Line-of-business app** under **Other**.
 
-3. Select **App package file**, and then browse to the location of the Configuration Manager file  **ccmsetup.msi**, and then select **Open > OK**.
+3. For the **App package file**, browse to the location of the Configuration Manager file  **ccmsetup.msi**, and then select **Open > OK**.
 For example, *C:\Program Files\Microsoft Configuration Manager\bin\i386\ccmsetup.msi*
 
 4. Select **App Information**, and then specify the following details:
@@ -407,11 +407,11 @@ For example, *C:\Program Files\Microsoft Configuration Manager\bin\i386\ccmsetup
 
 The following procedure deploys the app for installing the Configuration Manager client that you created in the previous procedure.
 
-1. Sign in to the [Azure portal](https://portal.azure.com/).  Select **All services > Intune > Client apps > Apps**, and then select **ConfigMgr Client Setup Bootstrap**, the app you created to deploy the Configuration Manager client.  
+1. Sign in to the [Microsoft Endpoint Manager admin center](https://endpoint.microsoft.com). Select **Apps** > **All Apps** and then select **ConfigMgr Client Setup Bootstrap**, the app you created to deploy the Configuration Manager client.  
 
-2. Select **Assignments > Add group**.  Set **Assignment type** as **Required**, and then use **Included Groups** and **Excluded Groups** to set the Azure Active Directory (AD) groups that have users and devices that you want to participate in co-management.  
+2. Click **Properties** then **Edit** for **Assignments**. Select **Add group** under **Required** assignments to set the Azure Active Directory (AD) groups that have users and devices that you want to participate in co-management.  
 
-3. Select **OK** and then **Save** the configuration.
+3. Select **Review + save** and then **Save** the configuration.
 The app is now required by users and devices you assigned it to. After the app installs the Configuration Manager client on a device, it's managed by co-management.
 
 ## Summary


### PR DESCRIPTION
Since the Intune portal in Azure will soon be replaced with endpoint.microsoft.com, I thought this should point there instead.