### PR TITLE
Apps workload doesn't be set to Intune/Pilot Intune for PowerShell sc…

### DIFF
--- a/memdocs/intune/apps/intune-management-extension.md
+++ b/memdocs/intune/apps/intune-management-extension.md
@@ -71,7 +71,7 @@ The Intune management extension has the following prerequisites. Once the prereq
     
     - User signs in to the device using their Azure AD account, and then enrolls in Intune.
 
-  - Co-managed devices that use Configuration Manager and Intune. Be sure the **Apps** workload is set to **Pilot Intune** or **Intune**. See the following articles for guidance: 
+  - Co-managed devices that use Configuration Manager and Intune. When installing Win 32 apps, make sure the **Apps** workload is set to **Pilot Intune** or **Intune**. PowerShell scripts will be run even if the **Apps** workload is set to **Configuration Manager**. See the following articles for guidance: 
   
     - [What is co-management](https://docs.microsoft.com/configmgr/comanage/overview) 
     - [Client apps workload](https://docs.microsoft.com/configmgr/comanage/workloads#client-apps)

--- a/memdocs/intune/apps/intune-management-extension.md
+++ b/memdocs/intune/apps/intune-management-extension.md
@@ -71,7 +71,7 @@ The Intune management extension has the following prerequisites. Once the prereq
     
     - User signs in to the device using their Azure AD account, and then enrolls in Intune.
 
-  - Co-managed devices that use Configuration Manager and Intune. When installing Win 32 apps, make sure the **Apps** workload is set to **Pilot Intune** or **Intune**. PowerShell scripts will be run even if the **Apps** workload is set to **Configuration Manager**. See the following articles for guidance: 
+  - Co-managed devices that use Configuration Manager and Intune. When installing Win 32 apps, make sure the **Apps** workload is set to **Pilot Intune** or **Intune**. PowerShell scripts will be run even if the **Apps** workload is set to **Configuration Manager**. The Intune management extension will be deployed to a device when you target a PowerShell script to the device, however, as noted above, the device must be a Azure AD or Hybrid Azure AD joined device and must be running Windows 10 RS1 or later. See the following articles for guidance: 
   
     - [What is co-management](https://docs.microsoft.com/configmgr/comanage/overview) 
     - [Client apps workload](https://docs.microsoft.com/configmgr/comanage/workloads#client-apps)


### PR DESCRIPTION
…ripts

Intune Management Extension will be installed to co-managed devices if you assign PowerShell scripts to co-managed devices and the Apps workload is set to "Configuration Manager".