### PR TITLE
Update quickstart-paths.md

### DIFF
--- a/memdocs/configmgr/comanage/quickstart-paths.md
+++ b/memdocs/configmgr/comanage/quickstart-paths.md
@@ -42,7 +42,6 @@ Here's what you need to set it up:
         - For federated domains
 - Client agent setting for hybrid Azure AD-join
 - Configure auto-enrollment of devices to Intune
-- Assign Intune user licenses
 - Enable co-management in Configuration Manager
 
 For a tutorial on this path, see [Tutorial: Enable co-management for existing Configuration Manager clients](tutorial-co-manage-clients.md).


### PR DESCRIPTION
A new license is now available that lets Configuration Manager customers with Software Assurance get Intune PC management rights without having to purchase an additional Intune license for co-management. You no longer need to purchase and assign individual Intune licenses to your users.  https://docs.microsoft.com/en-us/mem/configmgr/core/understand/product-and-licensing-faq#bkmk_mem