### PR TITLE
Added supported platforms for 'Remotely lock the noncompliant device'

### DIFF
--- a/memdocs/intune/protect/actions-for-noncompliance.md
+++ b/memdocs/intune/protect/actions-for-noncompliance.md
@@ -60,10 +60,12 @@ When the email is sent, Intune includes details about the noncompliant device in
 - **Remotely lock the noncompliant device**: Use this action to issue a remote lock of a device. The user is then prompted for a PIN or password to unlock the device. More on the [Remote Lock](../remote-actions/device-remote-lock.md) feature.
 
   The following platforms support this action:
-  - Android
-  - Android enterprise kiosk devices
-  - Android enterprise work profile devices
-  - iOS
+  - Android:
+    - Android device administrator
+    - Android Enterprise Device Owner
+    - Android Enterprise Work Profile
+    - Android Enterprise kiosk devices
+  - iOS/iPadOS
   - macOS
   - Windows 10 Mobile
   - Windows Phone 8.1 and later
@@ -71,8 +73,11 @@ When the email is sent, Intune includes details about the noncompliant device in
 - **Retire the noncompliant device**: This action removes all company data off the device and removes the device from Intune management. To prevent accidental wipe of a device, this action supports a minimum schedule of **30** days.
 
   The following platforms support this action:
-  - Android
-  - iOS
+  - Android:
+    - Android device administrator
+    - Android Enterprise Device Owner
+    - Android Enterprise Work Profile
+  - iOS/iPadOS
   - macOS
   - Windows 10 Mobile
   - Windows Phone 8.1 and later

--- a/memdocs/intune/protect/actions-for-noncompliance.md
+++ b/memdocs/intune/protect/actions-for-noncompliance.md
@@ -59,6 +59,15 @@ When the email is sent, Intune includes details about the noncompliant device in
 
 - **Remotely lock the noncompliant device**: Use this action to issue a remote lock of a device. The user is then prompted for a PIN or password to unlock the device. More on the [Remote Lock](../remote-actions/device-remote-lock.md) feature.
 
+  The following platforms support this action:
+  - Android
+  - Android enterprise kiosk devices
+  - Android enterprise work profile devices
+  - iOS
+  - macOS
+  - Windows 10 Mobile
+  - Windows Phone 8.1 and later
+
 - **Retire the noncompliant device**: This action removes all company data off the device and removes the device from Intune management. To prevent accidental wipe of a device, this action supports a minimum schedule of **30** days.
 
   The following platforms support this action:


### PR DESCRIPTION
@Brenduns & @msftsamyadav 
Editing  'Remotely lock the noncompliant device' to make it consistant with the other actions (like retire noncompliant & send push notifications) which explicitly call out which platforms are supported. Alternative is to highlight the opposite (ie) Windows 10 desktop is not supported.