### PR TITLE
Added clarification to version restrictions

### DIFF
--- a/memdocs/intune/enrollment/enrollment-restrictions-set.md
+++ b/memdocs/intune/enrollment/enrollment-restrictions-set.md
@@ -68,7 +68,7 @@ Default restrictions are automatically provided for both device type and device 
 3. Choose **Next** to go to the **Platform settings** page.
 4. Under **Platform**, choose **Allow** for the platforms that you want this restriction to allow.
     ![Screen cap for choosing platform settings](./media/enrollment-restrictions-set/choose-platform-settings.png)
-5. Under **Versions**, choose the minimum and maximum versions that you want the allowable platforms to support. Version restrictions only apply to devices enrolled with the Company Portal.
+5. Under **Versions**, choose the minimum and maximum versions that you want the allowable platforms to support. For iOS and Android, version restrictions only apply to devices enrolled with the Company Portal.
      Supported version formats include:
     - Android device administrator and Android Enterprise work profile support major.minor.rev.build.
     - iOS/iPadOS supports major.minor.rev. Operating system versions don't apply to Apple devices that enroll with the Device Enrollment Program, Apple School Manager, or the Apple Configurator app.


### PR DESCRIPTION
@ErikjeMS & @dagerrit 
Amended the note regarding version restrictions to clarify that it applies only to iOS and Android (via Company Portal). Meaning that version restrictions CAN be leveraged without the Company Portal, for Windows.