### PR TITLE
Fixed formatting of command examples

### DIFF
--- a/memdocs/intune/protect/certificates-scep-configure.md
+++ b/memdocs/intune/protect/certificates-scep-configure.md
@@ -227,9 +227,9 @@ By default, Intune uses the value configured in the template. However, you can c
 
 1. On the CA, run the following commands:
 
-   -**certutil -setreg Policy\EditFlags +EDITF_ATTRIBUTEENDDATE**
-   -**net stop certsvc**
-   -**net start certsvc**
+   **certutil -setreg Policy\EditFlags +EDITF_ATTRIBUTEENDDATE**  
+   **net stop certsvc**  
+   **net start certsvc**    
 
 2. On the issuing CA, use the Certification Authority snap-in to publish the certificate template. Select the **Certificate Templates** node, select **Action** > **New** > **Certificate Template to Issue**, and then select the certificate template you created in the previous section.
 


### PR DESCRIPTION
The commands had - in them that aren't needed and also were all on a single line.