### PR TITLE
.NET Framework 3.5 is a pre-requisite for the portals

### DIFF
--- a/memdocs/configmgr/protect/plan-design/bitlocker-management.md
+++ b/memdocs/configmgr/protect/plan-design/bitlocker-management.md
@@ -87,7 +87,7 @@ Let users help themselves with a single-use key for unlocking a BitLocker encryp
     > [!NOTE]
     > Only install the self-service portal and the administration and monitoring website with a primary site database. In a hierarchy, install these websites for each primary site.
 
-- On the web server that will host the self-service portal, install [Microsoft ASP.NET MVC 4.0](https://docs.microsoft.com/aspnet/mvc/mvc4).
+- On the web server that will host the self-service portal, install [Microsoft ASP.NET MVC 4.0](https://docs.microsoft.com/aspnet/mvc/mvc4) and .NET Framework 3.5 feature before staring the install process. Other required Windows server roles and features will be installed automatically during the portal installation process.
 
 - The user account that runs the portal installer script needs SQL **sysadmin** rights on the site database server. During the setup process, the script sets login, user, and SQL role rights for the web server machine account. You can remove this user account from the sysadmin role after you complete setup of the self-service portal and the administration and monitoring website.
 


### PR DESCRIPTION
You should add .NET Framework 3.5 as a pre-requisite for the MBAM portals. 

MBAMWebSiteInstaller.ps1 will try to install the required Windows server roles and features. One of the required features is WAS-NET-Environment, which requires .NET Framework 3.5. Because .NET Framework 3.5 installation requires SXS\microsoft-windows-netfx3-ondemand-package....cab file from the OS media, PowerShell script cannot install .NET Framework 3.5  And PowerShell will give you a cryptic error message that the installation fails. 

Other roles and features can be installed without files from OS media and thus those don't need to be listed as a pre-req.