### PR TITLE
Updated language to reflect client settings policy

### DIFF
--- a/memdocs/configmgr/sum/deploy-use/manage-express-installation-files-for-windows-10-updates.md
+++ b/memdocs/configmgr/sum/deploy-use/manage-express-installation-files-for-windows-10-updates.md
@@ -56,7 +56,9 @@ Once you deploy client settings to enable this functionality on the client, it a
 3. Select the appropriate client settings, and click **Properties** on the ribbon.  
 
 4. Select the **Software Updates** group. Configure to **Yes** the setting to **Enable installation of Express Updates on clients**. Configure the **Port used to download content for Express Updates** with the port used by the HTTP listener on the client.
+    - In version 1902, **Enable installation of Express Updates on clients** was changed to **Allow clients to download delta content when available**.
     - In version 1902, **Port used to download content for Express Updates** was changed to **Port that clients use to receive requests for delta content**.
+    
 
 ## Next steps
 


### PR DESCRIPTION
This is the original client setting that was referred to.
![image](https://user-images.githubusercontent.com/20917262/83980773-f206eb80-a8dd-11ea-9fac-f65133e721f3.png)

Here's what it looks like in 2002 (and previous versions). I don't know when it actually changed, but based on the 1902 note for the other verbiage, I matched it.

![image](https://user-images.githubusercontent.com/20917262/83980804-372b1d80-a8de-11ea-8801-3e439dfc4c2b.png)
