### PR TITLE
Dedupe folder vs volume support

### DIFF
--- a/memdocs/configmgr/core/plan-design/configs/support-for-windows-features-and-networks.md
+++ b/memdocs/configmgr/core/plan-design/configs/support-for-windows-features-and-networks.md
@@ -64,7 +64,7 @@ Configuration Manager provides support for clients in workgroups.
 Configuration Manager supports the use of data deduplication with distribution points on Windows Server 2012 or later.
 
 > [!IMPORTANT]  
-> The volume that hosts package source files can't be marked for data deduplication. This limitation is because data deduplication uses reparse points. Configuration Manager doesn't support using a content source location with files stored on reparse points.  
+> The folder(s) that host package source files can't be marked for data deduplication. This limitation is because data deduplication uses reparse points. Configuration Manager doesn't support using a content source location with files stored on reparse points.  
 
 For more information, see the following posts:
 


### PR DESCRIPTION
Per https://web.archive.org/web/20140310081022/http://blogs.technet.com/b/configmgrteam/archive/2014/02/18/configuration-manager-distribution-points-and-windows-server-2012-data-deduplication.aspx and other sources, the **FOLDER**(s) that host package source files can't be marked for data deduplication, not the **VOLUME**(s).