### PR TITLE
removed '/mode' from SetupDiag script example

### DIFF
--- a/memdocs/configmgr/osd/deploy-use/create-a-task-sequence-to-upgrade-an-operating-system.md
+++ b/memdocs/configmgr/osd/deploy-use/create-a-task-sequence-to-upgrade-an-operating-system.md
@@ -219,7 +219,7 @@ One such tool is Windows [SetupDiag](https://docs.microsoft.com/windows/deployme
 - In Configuration Manager, [create a package](../../apps/deploy-use/packages-and-programs.md#create-a-package-and-program) for the tool.  
 
 - Add a [Run Command Line](../understand/task-sequence-steps.md#BKMK_RunCommandLine) step to this group of your task sequence. Use the **Package** option to reference the tool. The following string is an example **Command line**:  
-    `SetupDiag.exe /Output:"%_SMSTSLogPath%\SetupDiagResults.log" /Mode:Online`  
+    `SetupDiag.exe /Output:"%_SMSTSLogPath%\SetupDiagResults.log"`  
 
 
 ## Additional recommendations

--- a/memdocs/configmgr/osd/deploy-use/create-a-task-sequence-to-upgrade-an-operating-system.md
+++ b/memdocs/configmgr/osd/deploy-use/create-a-task-sequence-to-upgrade-an-operating-system.md
@@ -221,6 +221,8 @@ One such tool is Windows [SetupDiag](https://docs.microsoft.com/windows/deployme
 - Add a [Run Command Line](../understand/task-sequence-steps.md#BKMK_RunCommandLine) step to this group of your task sequence. Use the **Package** option to reference the tool. The following string is an example **Command line**:  
     `SetupDiag.exe /Output:"%_SMSTSLogPath%\SetupDiagResults.log"`  
 
+> [!TIP]
+> Always use the most recent version of SetupDiag for the latest functionality and fixes to known issues. For more information, see [SetupDiag](https://docs.microsoft.com/windows/deployment/upgrade/setupdiag).
 
 ## Additional recommendations
 


### PR DESCRIPTION
as per https://docs.microsoft.com/en-us/windows/deployment/upgrade/setupdiag#parameters, the /Mode parameter is deprecated in version 1.4.0.0 of SetupDiag.