### PR TITLE
Page Improvement: Intune For Education

### DIFF
--- a/memdocs/intune/fundamentals/introduction-intune-education.md
+++ b/memdocs/intune/fundamentals/introduction-intune-education.md
@@ -29,11 +29,11 @@ ms.collection: M365-identity-device-management
 
 # How is Intune for Education different from the full device management experience in Intune?
 
-Intune for Education enables your teachers and students to be productive while protecting your school's data. Intune is a cloud-based enterprise mobility management (EMM) service that is the foundation for Intune for Education.
+Intune for Education enables your teachers and students to be productive while protecting your school's data. Intune for Education is powered by Microsoft’s Intune service which is a cloud-based enterprise mobility management (EMM) service.
 
 ![Intune for Education console compared against Intune console.](./media/introduction-intune-education/intune-azure-vs-intuneEDU.png)
 
-Intune for Education lets you manage Windows 10 and iOS/iPadOS devices using the full MDM capabilities available in Intune. The full device management experience lets you manage Windows, iOS/iPadOS, and Android devices.  
+Intune for Education lets you manage Windows 10 and iOS/iPadOS devices using the full MDM capabilities available in Intune. You can also manage Android devices by using the *full Intune console* instead of the *Intune for Education console*. The full Intune console comes included in Intune for Education. 
 
 Intune for Education can be used by itself, or in harmony with the [full device management experience available in Intune](what-is-intune.md). It can also be used alongside the rest of the tools available in [Microsoft Education](https://microsoft.com/education), which makes it easy for you to use Intune for Education with other useful educational tools from Microsoft.  
 

--- a/memdocs/intune/fundamentals/introduction-intune-education.md
+++ b/memdocs/intune/fundamentals/introduction-intune-education.md
@@ -33,7 +33,7 @@ Intune for Education enables your teachers and students to be productive while p
 
 ![Intune for Education console compared against Intune console.](./media/introduction-intune-education/intune-azure-vs-intuneEDU.png)
 
-Intune for Education lets you manage Windows 10 and iOS/iPadOS devices using the full MDM capabilities available in Intune. You can also manage Android devices by using the *full Intune console* instead of the *Intune for Education console*. The full Intune console comes included in Intune for Education. 
+Intune for Education lets you manage Windows 10 and iOS/iPadOS devices using the full MDM capabilities available in Intune. The full device management experience lets you manage Windows, iOS/iPadOS, and Android devices. 
 
 Intune for Education can be used by itself, or in harmony with the [full device management experience available in Intune](what-is-intune.md). It can also be used alongside the rest of the tools available in [Microsoft Education](https://microsoft.com/education), which makes it easy for you to use Intune for Education with other useful educational tools from Microsoft.  
 

--- a/memdocs/intune/fundamentals/introduction-intune-education.md
+++ b/memdocs/intune/fundamentals/introduction-intune-education.md
@@ -29,7 +29,7 @@ ms.collection: M365-identity-device-management
 
 # How is Intune for Education different from the full device management experience in Intune?
 
-Intune for Education enables your teachers and students to be productive while protecting your school's data. Intune for Education is powered by Microsoft’s Intune service which is a cloud-based enterprise mobility management (EMM) service.
+Intune for Education enables your teachers and students to be productive while protecting your school's data. Intune for Education is powered by Microsoft’s Intune service, a cloud-based enterprise mobility management (EMM) service.
 
 ![Intune for Education console compared against Intune console.](./media/introduction-intune-education/intune-azure-vs-intuneEDU.png)
 


### PR DESCRIPTION
On the Intune for Education page, I believe we can slightly improve two paragraphs. The first edit I would like to suggest is switching the order of "Intune" and "Intune For Education" in the intro paragraph, I think switching the order makes it more clear for users. The second edit I would like to suggest is specifically mentioning the "full Intune console" and "Intune for Education console" in the second paragraph. As a first-time user, I was slightly confused about what "full device management experience" meant until I did more research. Since we can manage Android devices by using the "full Intune console", I believe mentioning that here more clearly will help a lot of other users.

Thank you!