### PR TITLE
Update app-discovered-apps.md

### DIFF
--- a/memdocs/intune/apps/app-discovered-apps.md
+++ b/memdocs/intune/apps/app-discovered-apps.md
@@ -69,7 +69,7 @@ The following list provides the app platform type, the apps that are monitored f
 | Android Enterprise | Only managed apps | Only apps installed in the Work Profile | Every 7 days from device enrollment |
 
 > [!NOTE]
-> - Windows 10 Hybrid Azure AD joined devices, as shown in the app management workload in Configuration Manager, do not currently collect app inventory through the Intune Management Extension (IME) as per the above schedule. To mitigate this issue, the app management workload in Configuration Manager should be switched to Intune for the IME to be installed on the device (IME is required for Win32 inventory and PowerShell deployment). Note that any changes or updates on this behavior are announced in [in development](../fundamentals/in-development.md) and/or [what's new](../fundamentals/whats-new.md).
+> - Windows 10 Intune/MEMCM co-managed devices, as shown in the app management workload in Configuration Manager, do not currently collect app inventory through the Intune Management Extension (IME) as per the above schedule. To mitigate this issue, the app management workload in Configuration Manager should be switched to Intune for the IME to be installed on the device (IME is required for Win32 inventory and PowerShell deployment). Note that any changes or updates on this behavior are announced in [in development](../fundamentals/in-development.md) and/or [what's new](../fundamentals/whats-new.md).
 > - Personally-owned macOS devices enrolled before November 2019 may continue to show all apps installed on the device until the devices are enrolled again.
 > - Android Enterprise Fully Managed and Dedicated do not display discovered apps.
 


### PR DESCRIPTION
The workload slider should only relate to devices that are co-managed (as far as I'm aware).  Hybrid AAD join is not required for co-management or any particular configuration management approach.  I think the rest of this Note also needs clarity around if the app inventory being able to be collected within Intune is a product of having the IME only, or if the app inventory collection distinctly requires the app management workload be shifted (it currently reads like the app management workload shift is only required as a means to obtain the IME).