### PR TITLE
Update setup-cloud-management-gateway.md

### DIFF
--- a/memdocs/configmgr/core/clients/manage/cmg/setup-cloud-management-gateway.md
+++ b/memdocs/configmgr/core/clients/manage/cmg/setup-cloud-management-gateway.md
@@ -241,8 +241,9 @@ After creating a CMG, you can modify some of its settings. Select the CMG in the
 #### Settings
 
 - **Certificate file**: change the server authentication certificate for the CMG. This option is useful when updating the certificate before it expires.  
-> [!NOTE]  
-> When renewing the server authentication certificate for the CMG, the FQDN specified for the certificate's Common Name is case-sensitive.  For example, if the certificate currently in use has a CN of `https://contoso-cmg.contoso.com`, the new certificate must also have a CN of `https://contoso-cmg.contoso.com` as `https://CONTOSO-CMG.CONTOSO.COM` will not be accepted.
+
+  > [!NOTE]
+  > When you renew the server authentication certificate for the CMG, the FQDN specified for the certificate's Common Name (CN) is case-sensitive.  For example, if the certificate currently in use has a CN of `https://contoso-cmg.contoso.com`, create the new certificate with the same lowercase CN. The wizard won't accept a certificate with the CN `https://CONTOSO-CMG.CONTOSO.COM`.
 
 - **VM Instance**: change the number of virtual machines that the service uses in Azure. This setting allows you to dynamically scale the service up or down based on usage or cost considerations.  
 

--- a/memdocs/configmgr/core/clients/manage/cmg/setup-cloud-management-gateway.md
+++ b/memdocs/configmgr/core/clients/manage/cmg/setup-cloud-management-gateway.md
@@ -241,6 +241,8 @@ After creating a CMG, you can modify some of its settings. Select the CMG in the
 #### Settings
 
 - **Certificate file**: change the server authentication certificate for the CMG. This option is useful when updating the certificate before it expires.  
+> [!NOTE]  
+> When renewing the server authentication certificate for the CMG, the FQDN specified for the certificate's Common Name is case-sensitive.  For example, if the certificate currently in use has a CN of `https://contoso-cmg.contoso.com`, the new certificate must also have a CN of `https://contoso-cmg.contoso.com` as `https://CONTOSO-CMG.CONTOSO.COM` will not be accepted.
 
 - **VM Instance**: change the number of virtual machines that the service uses in Azure. This setting allows you to dynamically scale the service up or down based on usage or cost considerations.  
 


### PR DESCRIPTION
If you request a new certificate and don't use the exact same case as the current CMG instance, the wizard will not accept it do to two different CNames.  Error is "The existing certificate has a CName of MYCMG.CONTOSO.COM. The new certificate has a CName of mycmg.contoso.com. New certificate must have the same CName as previous certificate."