### PR TITLE
Added step to add Client Secret to request

### DIFF
--- a/memdocs/intune/developer/reports-proc-data-rest.md
+++ b/memdocs/intune/developer/reports-proc-data-rest.md
@@ -67,11 +67,11 @@ You now have an app defined in Azure. Grant access from the native app to the Mi
 6. Select **Delegated Permissions** box and click the **Get data warehouse information from Microsoft Intune** box.
 7. Click **Add permissions**.
 8. Optionally, Select **Grant admin consent for Microsoft** in the Configured permissions pane, then select **Yes**. This will grant access to all accounts in the current directory. This will prevent the consent dialog box from appearing for every user in the tenant. For more information, see [Integrating applications with Azure Active Directory](https://docs.microsoft.com/azure/active-directory/develop/active-directory-integrating-applications).
-9. Select **Certificates & secrets** > **+New client secret** and generate a new secret. Make sure to copy it some place safe as you will not be able to access it again.
+9. Select **Certificates & secrets** > **+ New client secret** and generate a new secret. Make sure to copy it someplace safe because you won't be able to access it again.
 
 ## Get data from the Microsoft Intune API with Postman
 
-You can work with the Intune Data Warehouse API with a generic REST client such as Postman. Postman can  provide insight into the features of the API, the underlying OData data model, and troubleshoot your  connection to the API resources. In this section, you can find information about generating an Auth2.0 token for your local client. The client will need the token to authenticate with Azure AD and access the API resources.
+You can work with the Intune Data Warehouse API with a generic REST client such as Postman. Postman can  provide insight into the features of the API, the underlying OData data model, and troubleshoot your connection to the API resources. In this section, you can find information about generating an Auth2.0 token for your local client. The client will need the token to authenticate with Azure AD and access the API resources.
 
 ### Information you will need to make the call
 
@@ -134,7 +134,7 @@ To get a new access token for Postman, you must add the Azure AD authorization U
 
      `Ksml3dhDJs+jfK1f8Mwc8 `
 
-12. Select **Authorization Code**, and Request access token locally.
+12. Select **Authorization Code** and **Request access token locally**.
 
 13. Select **Request Token**.
 

--- a/memdocs/intune/developer/reports-proc-data-rest.md
+++ b/memdocs/intune/developer/reports-proc-data-rest.md
@@ -67,6 +67,7 @@ You now have an app defined in Azure. Grant access from the native app to the Mi
 6. Select **Delegated Permissions** box and click the **Get data warehouse information from Microsoft Intune** box.
 7. Click **Add permissions**.
 8. Optionally, Select **Grant admin consent for Microsoft** in the Configured permissions pane, then select **Yes**. This will grant access to all accounts in the current directory. This will prevent the consent dialog box from appearing for every user in the tenant. For more information, see [Integrating applications with Azure Active Directory](https://docs.microsoft.com/azure/active-directory/develop/active-directory-integrating-applications).
+9. Select **Certificates & secrets** > **+New client secret** and generate a new secret. Make sure to copy it some place safe as you will not be able to access it again.
 
 ## Get data from the Microsoft Intune API with Postman
 
@@ -83,6 +84,7 @@ You need the following information to make a REST call using Postman:
 | Auth URL         | This is the URL used to authenticate. | https://login.microsoftonline.com/common/oauth2/authorize?resource=https://api.manage.microsoft.com/ |
 | Access Token URL | This is the URL used to grant the token.                                                                                                                                              | https://login.microsoftonline.com/common/oauth2/token |
 | Client ID        | You created, and noted this when creating the native app in Azure.                                                                                               | 4184c61a-e324-4f51-83d7-022b6a81b991                                                          |
+| Client Secret        | You created, and noted this when creating the native app in Azure.                                                                                               | Ksml3dhDJs+jfK1f8Mwc8                                                          |
 | Scope (Optional) | Blank                                                                                                                                                                               | You can leave the field blank.                                                                     |
 | Grant Type       | The token is an authorization code.                                                                                                                                                  | Authorization code                                                                            |
 
@@ -128,14 +130,18 @@ To get a new access token for Postman, you must add the Azure AD authorization U
 
      `88C8527B-59CB-4679-A9C8-324941748BB4`
 
-11. Select **Authorization Code**, and Request access token locally.
+11. Add the **Client Secret** you generated from within the native app that you created in Azure. It should look something like:  
 
-12. Select **Request Token**.
+     `Ksml3dhDJs+jfK1f8Mwc8 `
+
+12. Select **Authorization Code**, and Request access token locally.
+
+13. Select **Request Token**.
 
     ![Information for the access token](./media/reports-proc-data-rest/reports-postman_getnewtoken.png)
 
-13. Type your credentials in the Active AD authorization page. The list of tokens in Postman now contains the token named `Bearer`.
-14. Select **Use Token**. The list of headers contains the new key value of Authorization and the value `Bearer <your-authorization-token>`.
+14. Type your credentials in the Active AD authorization page. The list of tokens in Postman now contains the token named `Bearer`.
+15. Select **Use Token**. The list of headers contains the new key value of Authorization and the value `Bearer <your-authorization-token>`.
 
 #### Send the call to the endpoint using Postman
 

--- a/memdocs/intune/developer/reports-proc-data-rest.md
+++ b/memdocs/intune/developer/reports-proc-data-rest.md
@@ -134,7 +134,7 @@ To get a new access token for Postman, you must add the Azure AD authorization U
 
      `Ksml3dhDJs+jfK1f8Mwc8 `
 
-12. Select **Authorization Code** and **Request access token locally**.
+12. Select **Authorization Code** as the Grant Type.
 
 13. Select **Request Token**.
 


### PR DESCRIPTION
We received a customer ticket in which the customer followed this guide and was unable to authenticate. I was able to replicate this. In order to successfully authenticate I created a client secret within the native app and added that secret as part of the OAuth2 token. I've added these additional steps in this PR.