### PR TITLE
Azure AD Group Sync changes

### DIFF
--- a/memdocs/configmgr/core/clients/manage/collections/create-collections.md
+++ b/memdocs/configmgr/core/clients/manage/collections/create-collections.md
@@ -229,6 +229,7 @@ The Azure AD synchronization happens every five minutes. It's a one-way process,
 - Integration with Azure AD for [Cloud Management](../../../servers/deploy/configure/azure-services-wizard.md)
 - [Azure Active Directory user discovery](../../../servers/deploy/configure/about-discovery-methods.md#azureaddisc)
 - An HTTPS or [Enhanced HTTP](../../../plan-design/hierarchy/enhanced-http.md) enabled management point
+- Access to the **All Systems** collection
 
 ### Create a group and set the owner in Azure AD
 
@@ -250,7 +251,7 @@ The Azure AD synchronization happens every five minutes. It's a one-way process,
 
 1. In the Configuration Manager console, go to **Assets and Compliance** > **Overview** > **Device Collections**.
 1. Right-click on the collection to sync, then click **Properties**. 
-1. In the **AAD Group Sync** tab, click **Add**.
+1. In the **Cloud Sync** tab, click **Add**.
 1. From the drop-down menu, select the **Tenant** where you created your Azure AD group.
 1. Type in your search criteria in the **Name starts with** field, then click **Search**.
   - If you are prompted to sign in, use the identity you specified as the owner for the Azure AD group.


### PR DESCRIPTION
Added verbiage in the prerequisites section for Azure AD Group sync specifying that access to the All Systems collection is required. Without this you cannot add new or view existing synchronizations tied to a collection. Also updated the name of the reference to the tab to be "Cloud Sync" as it appears in ConfigMgr 2002.