### PR TITLE
Update whats-new.md

### DIFF
--- a/memdocs/intune/fundamentals/whats-new.md
+++ b/memdocs/intune/fundamentals/whats-new.md
@@ -530,6 +530,9 @@ When you [configure a notification message template](../protect/actions-for-nonc
 You can now set a tenant-wide toggle that removes the Intune license requirement for admins to access the MEM admin console and query graph APIs. Once you remove the license requirement, you can never reinstate it. 
 
 
+> [!Note]
+> Some actions, for instance the Teamviewer Connector flow, still require an Intune license to complete
+
 
 <!-- vvvvvvvvvvvvvvvvvvvvvv -->
 ### Scripts 

--- a/memdocs/intune/fundamentals/whats-new.md
+++ b/memdocs/intune/fundamentals/whats-new.md
@@ -531,7 +531,7 @@ You can now set a tenant-wide toggle that removes the Intune license requirement
 
 
 > [!Note]
-> Some actions, for instance the Teamviewer Connector flow, still require an Intune license to complete
+> Some actions, including the Teamviewer Connector flow, still require an Intune license to complete.
 
 
 <!-- vvvvvvvvvvvvvvvvvvvvvv -->


### PR DESCRIPTION
Adds a note to the entry "Admins no longer require an Intune license to access Microsoft Endpoint Manager admin console" specifying a license may still be required for some functions. After testing, it seems an Intune License is still required to add the Teamviewer Connector flow. I've been told this limitation is by design, in which case it would be best to document some of these features may still not work by design.