### PR TITLE
add remote wipe under feature

### DIFF
--- a/memdocs/configmgr/core/understand/product-and-licensing-faq.md
+++ b/memdocs/configmgr/core/understand/product-and-licensing-faq.md
@@ -97,6 +97,7 @@ The co-management license lets Configuration Manager customers with Software Ass
 |Software update management|Yes|Yes|
 |Inventory|Yes|Yes|
 |App management|Yes|Yes|
+|Remote Full/Selective wipe|Yes|Yes|
 |Remote assistance<br>(TeamViewer license required)|Yes|Yes|
 |Desktop analytics<br>(Windows subscription licenses required|Yes|N/A|
 |Tenant attach|Yes|N/A|


### PR DESCRIPTION
suggestion to callout remote wipe feature for both co-management and full intune license as this is a common ask by customers

it is available in both set of licenses and you can remotely perform a full or selective wipe