### PR TITLE
Update packages-and-programs.md

### DIFF
--- a/memdocs/configmgr/apps/deploy-use/packages-and-programs.md
+++ b/memdocs/configmgr/apps/deploy-use/packages-and-programs.md
@@ -65,6 +65,8 @@ Packages can use some new features of Configuration Manager, including distribut
 
         > [!NOTE]  
         > The computer account of the site server must have read access permissions to the source folder that you specify.  
+        > Source Path should be less that equal to 255 characters OS limit, This applies to Package source as well as application, For naming convention, Please refer to
+          https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file 
 
     - Starting in version 1906, if you want to pre-cache content on a client, specify the **Architecture** and **Language** of the package. For more information, see [Configure pre-cache content](../../osd/deploy-use/configure-precache-content.md).<!--4224642-->  
 

--- a/memdocs/configmgr/apps/deploy-use/packages-and-programs.md
+++ b/memdocs/configmgr/apps/deploy-use/packages-and-programs.md
@@ -64,9 +64,9 @@ Packages can use some new features of Configuration Manager, including distribut
     - **Source folder**: If the package contains source files, choose **Browse** to open the **Set Source Folder** dialog box, and then specify the location of the source files for the package.  
 
         > [!NOTE]  
-        > The computer account of the site server must have read access permissions to the source folder that you specify.  
-        > Source Path should be less that equal to 255 characters OS limit, This applies to Package source as well as application, For naming convention, Please refer to
-          https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file 
+        > The computer account of the site server must have read access permissions to the source folder that you specify.
+        >
+        > Windows limits the source path to 256 characters or less. This limit applies to package source as well as applications. For more information, see [Naming Files, Paths, and Namespaces](/windows/win32/fileio/naming-a-file).
 
     - Starting in version 1906, if you want to pre-cache content on a client, specify the **Architecture** and **Language** of the package. For more information, see [Configure pre-cache content](../../osd/deploy-use/configure-precache-content.md).<!--4224642-->  
 


### PR DESCRIPTION
Character limit is nowhere mentioned in our docs
We do have status message for it
The package source directory contains files with long file names and the total length of the path exceeds the maximum length supported by the operating system
MessageID=2302
https://docs.microsoft.com/en-us/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN