### PR TITLE
Added Company Portal app version requirement

### DIFF
--- a/memdocs/configmgr/comanage/company-portal.md
+++ b/memdocs/configmgr/comanage/company-portal.md
@@ -47,6 +47,8 @@ For more information, see the following articles:
 
 - Configuration Manager current branch version 2006 or later
 
+- Company Portal app version 11.0.8980.0 or later
+
 - Windows 10, version 1803 or later:
 
   - Enrolled to [co-management](how-to-enable.md)


### PR DESCRIPTION
Hi Aaron, the required company portal app version has not fully rolled out to all tenants yet. I thought it may be useful to include the version of Company Portal app that is required for ConfigMgr apps to appear in the Company Portal. Thanks. Ben