### PR TITLE
Propose removing Company Portal App preview onboarding

### DIFF
--- a/memdocs/configmgr/core/get-started/2020/includes/2006/3601237.md
+++ b/memdocs/configmgr/core/get-started/2020/includes/2006/3601237.md
@@ -34,10 +34,7 @@ For more information, see [How to switch Configuration Manager workloads to Intu
 
 ### <a name="bkmk_prereq"></a> Prerequisites for Company Portal preview
 
-- Contact the Company Portal preview team to get started: `cppreview@microsoft.com`
-
-    > [!TIP]
-    > Once onboarded, access the preview content at `https://aka.ms/cppreview`.
+- Company Portal app version 11.0.8980.0 or later
 
 - Windows 10, version 1803 or later:
 


### PR DESCRIPTION
It is no longer a requirement to request onboarding for the Company Portal app. The functionality for viewing Configuration Manager apps in the Company Portal is already rolling out in the August version of the Company Portal app 11.0.8980.0

See PR https://github.com/MicrosoftDocs/memdocs/pull/682 for similar PR