### PR TITLE
Update domain-join-configure.md

### DIFF
--- a/memdocs/intune/configuration/domain-join-configure.md
+++ b/memdocs/intune/configuration/domain-join-configure.md
@@ -7,7 +7,7 @@ keywords:
 author: MandiOhlinger
 ms.author: mandia
 manager: dougeby
-ms.date: 05/13/2020
+ms.date: 08/31/2020
 ms.topic: how-to
 ms.service: microsoft-intune
 ms.subservice: configuration
@@ -72,7 +72,7 @@ This article shows you how to create a domain join profile for a hybrid Autopilo
 
 10. In **Assignments**, select the device groups that will receive your profile. For more information on assigning profiles, see [Assign user and device profiles](device-profile-assign.md).
 
-Note: Different groups can be used if there is a need to join devices to different domains or OUs
+    If you need to join devices to different domains or organizational units (OU), then create different device groups.
 
     Select **Next**.
 

--- a/memdocs/intune/configuration/domain-join-configure.md
+++ b/memdocs/intune/configuration/domain-join-configure.md
@@ -70,7 +70,9 @@ This article shows you how to create a domain join profile for a hybrid Autopilo
 
     Select **Next**.
 
-10. In **Assignments**, select the users or user group that will receive your profile. For more information on assigning profiles, see [Assign user and device profiles](device-profile-assign.md).
+10. In **Assignments**, select the device groups that will receive your profile. For more information on assigning profiles, see [Assign user and device profiles](device-profile-assign.md).
+
+Note: Different groups can be used if there is a need to join devices to different domains or OUs
 
     Select **Next**.
 

--- a/memdocs/intune/configuration/domain-join-configure.md
+++ b/memdocs/intune/configuration/domain-join-configure.md
@@ -70,9 +70,9 @@ This article shows you how to create a domain join profile for a hybrid Autopilo
 
     Select **Next**.
 
-10. In **Assignments**, select the device groups that will receive your profile. For more information on assigning profiles, see [Assign user and device profiles](device-profile-assign.md).
+10. In **Assignments**, select the device groups that will receive your profile. For more information about assigning profiles, see [Assign user and device profiles](device-profile-assign.md).
 
-    If you need to join devices to different domains or organizational units (OU), then create different device groups.
+    If you need to join devices to different domains or OUs, create different device groups.
 
     Select **Next**.
 


### PR DESCRIPTION
Domain Join Profile cannot be assigned to user groups. Clarify that only has to be assigned to Device Groups
Alternatively, different groups can be used if there is a need to join devices to different domains or OUs