### PR TITLE
Added info to clarify the storage location

### DIFF
--- a/memdocs/configmgr/core/servers/manage/powerbi-report-server.md
+++ b/memdocs/configmgr/core/servers/manage/powerbi-report-server.md
@@ -99,9 +99,15 @@ Only use this process if you don't already have a reporting services point in th
 
 1. When the report is ready to save, go to the **File** menu, select **Save as**, then choose **Power BI Report Server**.
 
-1. In the **Power BI Report Server Selection** window, enter the URL for the reporting services point as the **New report server address**. For example, `https://rsp.contoso.com/Reports`.
+1. In the **Power BI Report Server Selection** window, enter the URL for the reporting services point as the **New report server address**. For example, `https://rsp.contoso.com/Reports`. Click OK.
 
-In the Configuration Manager console, you see the new report in the list of Power BI Reports.
+1. In the **Save report** window, select the folder `ConfigMgr_<SiteCode>`, for example: `ConfigMgr_PS1` where `PS1` is the ConfigMgr site code. You can optionally choose or create (from the report server) a sub folder to store in.
+    > [!TIP]
+    > Reports and report folders with Power BI reports must be located in the `ConfigMgr_<SiteCode>` on the report server or they will not appear in the ConfigMgr console.
+
+1. In `File name:` field, enter a name for the report.
+
+In the Configuration Manager console, you see the new report in the list of Power BI Reports. If you don't see your reports, verify that you saved the reports to the `ConfigMgr_<SiteCode>` folder.
 
 ## Next steps
 

--- a/memdocs/configmgr/core/servers/manage/powerbi-report-server.md
+++ b/memdocs/configmgr/core/servers/manage/powerbi-report-server.md
@@ -99,13 +99,13 @@ Only use this process if you don't already have a reporting services point in th
 
 1. When the report is ready to save, go to the **File** menu, select **Save as**, then choose **Power BI Report Server**.
 
-1. In the **Power BI Report Server Selection** window, enter the URL for the reporting services point as the **New report server address**. For example, `https://rsp.contoso.com/Reports`. Click OK.
+1. In the **Power BI Report Server Selection** window, enter the URL for the reporting services point as the **New report server address**. For example, `https://rsp.contoso.com/Reports`. Select **OK**.
 
-1. In the **Save report** window, double click the folder `ConfigMgr_<SiteCode>`, for example: `ConfigMgr_PS1` where `PS1` is the ConfigMgr site code. You can optionally choose or create (from the report server) a sub folder to store in.
+1. In the **Save report** window, double-click the `ConfigMgr_<SiteCode>` folder. For example, `ConfigMgr_PS1`, where `PS1` is the ConfigMgr site code. You can optionally choose or create (from the report server) a sub folder to store it in.
     > [!TIP]
-    > Reports and report folders with Power BI reports must be located in the `ConfigMgr_<SiteCode>` on the report server or they will not appear in the ConfigMgr console.
+    > Reports and report folders with Power BI reports must be located in the `ConfigMgr_<SiteCode>` folder on the report server or they won't appear in the Configuration Manager console.
 
-1. In `File name:` field, enter a name for the report.
+1. In **File name**, enter a name for the report.
 
 In the Configuration Manager console, you see the new report in the list of Power BI Reports. If you don't see your reports, verify that you saved the reports to the `ConfigMgr_<SiteCode>` folder.
 

--- a/memdocs/configmgr/core/servers/manage/powerbi-report-server.md
+++ b/memdocs/configmgr/core/servers/manage/powerbi-report-server.md
@@ -101,7 +101,7 @@ Only use this process if you don't already have a reporting services point in th
 
 1. In the **Power BI Report Server Selection** window, enter the URL for the reporting services point as the **New report server address**. For example, `https://rsp.contoso.com/Reports`. Click OK.
 
-1. In the **Save report** window, select the folder `ConfigMgr_<SiteCode>`, for example: `ConfigMgr_PS1` where `PS1` is the ConfigMgr site code. You can optionally choose or create (from the report server) a sub folder to store in.
+1. In the **Save report** window, double click the folder `ConfigMgr_<SiteCode>`, for example: `ConfigMgr_PS1` where `PS1` is the ConfigMgr site code. You can optionally choose or create (from the report server) a sub folder to store in.
     > [!TIP]
     > Reports and report folders with Power BI reports must be located in the `ConfigMgr_<SiteCode>` on the report server or they will not appear in the ConfigMgr console.
 


### PR DESCRIPTION
The default storage location for reports is the root of the report server. Reports aren't saved into the ConfigMgr_<SiteCode> folder or any subfolder within that folder, they won't appear in the console.

![image](https://user-images.githubusercontent.com/20917262/91937141-f2cdd480-ecb6-11ea-91ea-e19db83093e2.png)

![image](https://user-images.githubusercontent.com/20917262/91937314-404a4180-ecb7-11ea-916a-08a7d537c479.png)
