### PR TITLE
Add "CA Account" instructions to PFX Connector section

### DIFF
--- a/memdocs/intune/protect/certficates-pfx-configure.md
+++ b/memdocs/intune/protect/certficates-pfx-configure.md
@@ -143,9 +143,13 @@ Before you begin, [review requirements for the connector](certificate-connectors
    > [!WARNING]
    > By default, in Windows Server **IE Enhanced Security Configuration** is set to **On** which can cause issues with the sign-in to Office 365.
 
-6. Close the window.
+6. Select the **CA Account** tab, and then enter credentials for an account that has the Issue and Manage Certificates permission on your issuing Certificate Authority. These credentials will be used to perform certificate revocation on the Certificate Authority. 
 
-7. In the Microsoft Endpoint Manager admin center, go back to **Tenant administration** > **Connectors and tokens** > **Certificate connectors**. In a few moments, a green check mark appears and the connection status updates. The connector server can now communicate with Intune.
+    **Apply*** your changes.
+
+7. Close the window.
+
+8. In the Microsoft Endpoint Manager admin center, go back to **Tenant administration** > **Connectors and tokens** > **Certificate connectors**. In a few moments, a green check mark appears and the connection status updates. The connector server can now communicate with Intune.
 
 ## Create a trusted certificate profile
 

--- a/memdocs/intune/protect/certficates-pfx-configure.md
+++ b/memdocs/intune/protect/certficates-pfx-configure.md
@@ -145,7 +145,7 @@ Before you begin, [review requirements for the connector](certificate-connectors
 
 6. Select the **CA Account** tab, and then enter credentials for an account that has the Issue and Manage Certificates permission on your issuing Certificate Authority. These credentials will be used to perform certificate revocation on the Certificate Authority. 
 
-    **Apply*** your changes.
+    **Apply** your changes.
 
 7. Close the window.
 


### PR DESCRIPTION
Added instructions for configuring the PFX Certificate Connector for revocation by adding CA credentials in the "CA Account" tab.