### PR TITLE
Indent caused image not to display

### DIFF
--- a/memdocs/configmgr/sum/get-started/software-update-point-ssl.md
+++ b/memdocs/configmgr/sum/get-started/software-update-point-ssl.md
@@ -156,7 +156,7 @@ Open the WSUS console to verify you can use an SSL connection to the WSUS server
 
 1. The **Use Secure Sockets Layer (SSL) to connect to this server** option automatically enables when either 8531 (default) or 443 are chosen.
 
-       :::image type="content" source="media/connect-wsus-console.png" alt-text="Connect to the WSUS console over the HTTPS port":::
+   :::image type="content" source="media/connect-wsus-console.png" alt-text="Connect to the WSUS console over the HTTPS port":::
        
 1. If your Configuration Manager site server is remote from the software update point, launch the WSUS console from the site server and verify the WSUS console can connect over SSL.
    - If the remote WSUS console can't connect, it likely indicates a problem with either trusting the certificate, name resolution, or the port being blocked.


### PR DESCRIPTION
Removed extra indent on connect-wsus-console.png image which was I think causing it not to display in the article, and instead appearing as a code block.