### PR TITLE
Update install-a-software-update-point.md

### DIFF
--- a/memdocs/configmgr/sum/get-started/install-a-software-update-point.md
+++ b/memdocs/configmgr/sum/get-started/install-a-software-update-point.md
@@ -90,6 +90,11 @@ ms.assetid: b099a645-6434-498f-a408-1d438e394396
 
     > [!NOTE]  
     >  When there is a firewall between the software update point and the Internet, the firewall might need to be configured to accept the HTTP and HTTPS ports that are used for the WSUS Web site. You can also choose to restrict access on the firewall to limited domains. For more information about how to plan for a firewall that supports software updates, see [Configure firewalls](../plan-design/plan-for-software-updates.md#BKMK_ConfigureFirewalls).  
+    
+        > [!NOTE]  
+    > A note about WSUS shared database:
+      If you are sharing database of WSUS with others, Please be aware that ConfigMgr chooses the software update point randomly between
+      shared WSUS. Please make sure that all the internet access requirements are met for every single shared WSUS. If not, then sync failures can occur if Parent WSUS/SUP has    shared database. Also you may see different software update points syncing with Microsoft each time and that is by design.
 
 -   **<a name="BKMK_wsussync"></a>Synchronize from an upstream data source location**: Use this setting to synchronize software updates metadata from the upstream synchronization source. The child primary sites and secondary sites are automatically configured to use the parent site URL for this setting. You have the option to synchronize software updates from an existing WSUS server. Specify a URL, such as `https://WSUSServer:8531`, where 8531 is the port that is used to connect to the WSUS server.  
 

--- a/memdocs/configmgr/sum/get-started/install-a-software-update-point.md
+++ b/memdocs/configmgr/sum/get-started/install-a-software-update-point.md
@@ -5,7 +5,7 @@ description: "Primary sites require a software update point on the central admin
 author: mestew 
 ms.author: mstewart
 manager: dougeby
-ms.date: 09/16/2020
+ms.date: 10/16/2020
 ms.topic: conceptual
 ms.prod: configuration-manager
 ms.technology: configmgr-sum
@@ -26,10 +26,8 @@ ms.assetid: b099a645-6434-498f-a408-1d438e394396
  The software update point is required on the central administration site and on the primary sites to enable software updates compliance assessment and to deploy software updates to clients. The software update point is optional on secondary sites. The software update point site system role must be created on a server that has WSUS installed. The software update point interacts with the WSUS services to configure the software update settings and to request synchronization of software updates metadata. When you have a Configuration Manager hierarchy, install and configure the software update point on the central administration site first, then on child primary sites, and then optionally, on secondary sites. When you have a stand-alone primary site, not a central administration site, install and configure the software update point on the primary site first, and then optionally, on secondary sites. Some settings are only available when you configure the software update point on a top-level site. There are different options that you must consider depending on where you installed the software update point.  
 
 > [!IMPORTANT]  
->  You can install more than one software update points on a site. The first software update point that you install is configured as the synchronization source, which synchronizes the updates from Microsoft Update or from the upstream synchronization source. The other software update points on the site are configured as replicas of the first software update point. Therefore, some settings are not available after you install and configure the initial software update point.  
-
-> [!IMPORTANT]  
->  It is not supported to install the software update point site system role on a server that has been configured and used as a standalone WSUS server or using a software update point to directly manage WSUS clients. Existing WSUS servers are only supported as upstream synchronization sources for the active software update point. See [Synchronize from an upstream data source location](#BKMK_wsussync)
+> - You can install more than one software update points on a site. The first software update point that you install is configured as the synchronization source, which synchronizes the updates from Microsoft Update or from the upstream synchronization source. The other software update points on the site are configured as replicas of the first software update point. Therefore, some settings are not available after you install and configure the initial software update point.  
+> - It is not supported to install the software update point site system role on a server that has been configured and used as a standalone WSUS server or using a software update point to directly manage WSUS clients. Existing WSUS servers are only supported as upstream synchronization sources for the active software update point. See [Synchronize from an upstream data source location](#BKMK_wsussync)
 
  You can add the software update point site system role to an existing site system server or you can create a new one. On the **System Role Selection** page of the **Create Site System Server Wizard** or **Add Site System Roles Wizard**, depending on whether you add the site system role to a new or existing site server, select **Software update point**, and then configure the software update point settings in the wizard. The settings are different depending on the version of Configuration Manager that you use. For more information about how to install site system roles, see [Install site system roles](../../core/servers/deploy/configure/install-site-system-roles.md).  
 
@@ -86,22 +84,15 @@ ms.assetid: b099a645-6434-498f-a408-1d438e394396
 
  The following list provides more information about each option that you can use as the synchronization source:  
 
--   **Synchronize from Microsoft Update**: Use this setting to synchronize software updates metadata from Microsoft Update. The central administration site must have Internet access; otherwise, synchronization will fail. This setting is available only when you configure the software update point on the top-level site.  
+- **Synchronize from Microsoft Update**: Use this setting to synchronize software updates metadata from Microsoft Update. The central administration site must have Internet access; otherwise, synchronization will fail. This setting is available only when you configure the software update point on the top-level site.  
 
-    > [!NOTE]  
-    >  When there is a firewall between the software update point and the Internet, the firewall might need to be configured to accept the HTTP and HTTPS ports that are used for the WSUS Web site. You can also choose to restrict access on the firewall to limited domains. For more information about how to plan for a firewall that supports software updates, see [Configure firewalls](../plan-design/plan-for-software-updates.md#BKMK_ConfigureFirewalls).  
-    
-        > [!NOTE]  
-    > A note about WSUS shared database:
-      If you are sharing database of WSUS with others, Please be aware that ConfigMgr chooses the software update point randomly between
-      shared WSUS. Please make sure that all the internet access requirements are met for every single shared WSUS. If not, then sync failures can occur if Parent WSUS/SUP has    shared database. Also you may see different software update points syncing with Microsoft each time and that is by design.
+   - When there's a firewall between the software update point and the Internet, the firewall might need to be configured to accept the HTTP and HTTPS ports that are used for the WSUS Web site. You can also choose to restrict access on the firewall to limited domains. For more information about how to plan for a firewall that supports software updates, see [Configure firewalls](../plan-design/plan-for-software-updates.md#BKMK_ConfigureFirewalls).  
+
+   - If you're sharing the WSUS database, be aware that Configuration Manager randomly chooses the software update point between the front-end WSUS servers. Ensure that the [internet access requirements](../../core/plan-design/network/internet-endpoints.md#bkmk_sum) are met for each of the WSUS servers. If internet access requirements aren't met, then sync failures can occur. You may see different software update points at the top-level site syncing with Microsoft.
 
 -   **<a name="BKMK_wsussync"></a>Synchronize from an upstream data source location**: Use this setting to synchronize software updates metadata from the upstream synchronization source. The child primary sites and secondary sites are automatically configured to use the parent site URL for this setting. You have the option to synchronize software updates from an existing WSUS server. Specify a URL, such as `https://WSUSServer:8531`, where 8531 is the port that is used to connect to the WSUS server.  
 
 -   **Do not synchronize from Microsoft Update or upstream data source**: Use this setting to manually synchronize software updates when the software update point at the top-level site is disconnected from the Internet. For more information, see [Synchronize software updates from a disconnected software update point](synchronize-software-updates-disconnected.md).  
-
-> [!NOTE]  
->  When there is a firewall between the software update point and the Internet, the firewall might need to be configured to accept the HTTP and HTTPS ports that are used for the WSUS Web site. You can also choose to restrict access on the firewall to limited domains. For more information about how to plan for a firewall that supports software updates, see [Configure firewalls](../plan-design/plan-for-software-updates.md#BKMK_ConfigureFirewalls).  
 
  You can also configure whether to create WSUS reporting events on the **Synchronization Source** page of the wizard or on the **Sync Settings** tab in Software Update Point Component Properties. Configuration Manager doesn't use these events; therefore, you will normally choose the default setting **Do not create WSUS reporting events**.  
 


### PR DESCRIPTION
The comment is this
A note about WSUS shared database:

If you are sharing database of WSUS with others, Please be aware that ConfigMgr chooses the software update point randomly between
shared WSUS. Please make sure that all the internet access requirements are met for every single shared WSUS.
If not, then sync failures can occur if Parent WSUS/SUP has shared database.

Also you may see different software update points syncing with Microsoft each time and that is by design.



This is due to design change in 1902 where WSYNCMgr picks random SUPs when shared DB is used
Code line is this

    {
        Log(LOG_DEBUG, "SelectSyncSup: Selecting randomly from usable SUPs.");
        result = **std::find( supList.begin(), supList.end(), PickRandom(wsusList));
    }**