### PR TITLE
Update server-auth-cert.md

### DIFF
--- a/memdocs/configmgr/core/clients/manage/cmg/server-auth-cert.md
+++ b/memdocs/configmgr/core/clients/manage/cmg/server-auth-cert.md
@@ -89,7 +89,8 @@ If you also enable the CMG for content, confirm that it's also a unique Azure st
 
 - Test your name in the **Storage account name** field.
 
-The DNS name prefix, for example `GraniteFalls`, should be 3 to 24 characters long, and only use alphanumeric characters. Don't use special characters, like a dash (`-`).<!-- SCCMDocs#1080 -->
+> [!IMPORTANT] The DNS name prefix, for example `GraniteFalls`, should be 3 to 24 characters long, and only use alphanumeric characters. Don't use special characters, like a 
+> dash (`-`).<!-- SCCMDocs#1080 -->
 
 ## Issue the certificate
 

--- a/memdocs/configmgr/core/clients/manage/cmg/server-auth-cert.md
+++ b/memdocs/configmgr/core/clients/manage/cmg/server-auth-cert.md
@@ -89,7 +89,8 @@ If you also enable the CMG for content, confirm that it's also a unique Azure st
 
 - Test your name in the **Storage account name** field.
 
-> [!IMPORTANT] The DNS name prefix, for example `GraniteFalls`, should be 3 to 24 characters long, and only use alphanumeric characters. Don't use special characters, like a 
+> [!IMPORTANT]
+> The DNS name prefix, for example `GraniteFalls`, should be 3 to 24 characters long, and only use alphanumeric characters. Don't use special characters, like a 
 > dash (`-`).<!-- SCCMDocs#1080 -->
 
 ## Issue the certificate


### PR DESCRIPTION
Just adding an IMPORTANT - not one the DNS prefix - section. 

I've had a few customers miss this and then they just create a certificate in the next step... they miss it and then have to cancel and re-issue the public cert. 

Would be nice to ensure they have a little more visibility on this critical step.