### PR TITLE
Update bundle-ids-built-in-ios-apps.md

### DIFF
--- a/memdocs/intune/configuration/bundle-ids-built-in-ios-apps.md
+++ b/memdocs/intune/configuration/bundle-ids-built-in-ios-apps.md
@@ -7,7 +7,7 @@ keywords:
 author: MandiOhlinger
 ms.author: mandia
 manager: dougeby
-ms.date: 02/18/2020
+ms.date: 10/19/2020
 ms.topic: reference
 ms.service: microsoft-intune
 ms.subservice: configuration
@@ -83,7 +83,7 @@ When you configure features on iOS/iPadOS devices, you can also add the built-in
 | com.apple.Passbook          | Wallet       | Apple     |
 | com.apple.Bridge            | Watch        | Apple     |
 | com.apple.weather           | Weather      | Apple     |
-| cocom.apple.barcodesupport.qrcode| QR Code Reader | Apple |
+| com.apple.barcodesupport.qrcode| QR Code Reader | Apple |
 
 ## Next steps
 

--- a/memdocs/intune/configuration/bundle-ids-built-in-ios-apps.md
+++ b/memdocs/intune/configuration/bundle-ids-built-in-ios-apps.md
@@ -83,6 +83,7 @@ When you configure features on iOS/iPadOS devices, you can also add the built-in
 | com.apple.Passbook          | Wallet       | Apple     |
 | com.apple.Bridge            | Watch        | Apple     |
 | com.apple.weather           | Weather      | Apple     |
+| cocom.apple.barcodesupport.qrcode| QR Code Reader | Apple |
 
 ## Next steps
 


### PR DESCRIPTION
Adding the built-in QR code reader as iOS 14.x now prevents the scanner to be used when "visible apps" is setup and QR code is not specified.

https://support.apple.com/en-us/HT208843