### PR TITLE
Removing mentions to NDES in PKCS Troubleshooting

### DIFF
--- a/memdocs/intune/protect/troubleshoot-pkcs-certificate-profiles.md
+++ b/memdocs/intune/protect/troubleshoot-pkcs-certificate-profiles.md
@@ -74,9 +74,9 @@ Device logs depend on the device platform:
 
 ### Logs for on-premises infrastructure
   
-On-premises infrastructure that supports use of PKCS certificate profiles for certificate deployments includes the Microsoft Intune Certificate Connector, NDES that runs on a Windows Server, and the certification authority.
+On-premises infrastructure that supports use of PKCS certificate profiles for certificate deployments includes the Microsoft Intune Certificate Connector and the certification authority.
 
-Log files for these roles include Windows Event Viewer, Certificate consoles, and various log files specific to the Intune Certificate Connector, NDES, or other role and operations that are part of the on-premises infrastructure.
+Log files for these roles include Windows Event Viewer, Certificate consoles, and various log files specific to the Intune Certificate Connector, or other role and operations that are part of the on-premises infrastructure.
 
 - **NDESConnector_date_time.svclog**:
 
@@ -84,23 +84,11 @@ Log files for these roles include Windows Event Viewer, Certificate consoles, an
 
   Related registry key: *HKLM\SW\Microsoft\MicrosoftIntune\NDESConnector\ConnectionStatus*
 
-  Location: On the server that hosts NDES at *%program_files%\Microsoft intune\ndesconnectorsvc\logs\logs*
-
-- **CertificateRegistrationPoint_date_time.svclog**:
-
-  This log shows the NDES policy module receiving and verifying certificate requests. You can use the [Service Trace Viewer Tool](/dotnet/framework/wcf/service-trace-viewer-tool-svctraceviewer-exe) to view this log file.
-
-  Location: On the server that hosts NDES at *%program_files%\Microsoft intune\ndesconnectorsvc\logs\logs*
-
-- **NDESPlugin.log**:
-
-  This log shows the passing of certificate requests to the Certificate Registration Point, and the resulting verification of those requests.
-
-  Location: On the server that hosts NDES at *%program_files%\Microsoft Intune\NDESPolicyModule\logs*
+  Location: On the server that hosts the Intune PKCS Connector at *%program_files%\Microsoft intune\ndesconnectorsvc\logs\logs*
 
 - **Windows Application log**:
 
-  Location: On the server that hosts NDES: Run **eventvwr.msc** to open Windows Event Viewer
+  Location: On the server that hosts the Intune PKCS Connector: Run **eventvwr.msc** to open Windows Event Viewer
 
 ### Logs for Android devices
 
@@ -136,9 +124,9 @@ On the device, open **Event Viewer** > **Applications and Services Logs** > **Mi
 
 ## Antivirus exclusions
 
-Consider adding Antivirus exclusions on servers that host NDES or the certificate connector when:
+Consider adding Antivirus exclusions on servers that host the Intune PKCS Connector when:
 
-- Certificate requests reach the server or the Intune Certificate Connector, but are not successfully processed 
+- Certificate requests reach the server or the Intune PKCS Connector, but are not successfully processed 
 - Certificates are issued slowly
 
 The following are examples of locations that you might exclude:
@@ -161,7 +149,7 @@ The following common errors are each addressed in a following section:
 
 ### The RPC server is unavailable 0x800706ba
 
-During PFX deployment, the trusted root certificate appears on the device but the PFX certificate doesn't appear on the device. The NDESConnector log file contains the string **The RPC server is unavailable. 0x800706ba**, as seen in the first line of the following example:
+During PFX deployment, the trusted root certificate appears on the device but the PFX certificate doesn't appear on the device. The NDESConnector_date_time.svclog log file contains the string **The RPC server is unavailable. 0x800706ba**, as seen in the first line of the following example:
 
 ```
 IssuePfx - COMException: System.Runtime.InteropServices.COMException (0x800706BA): CCertRequest::Submit: The RPC server is unavailable. 0x800706ba (WIN32: 1722 RPC_S_SERVER_UNAVAILABLE)
@@ -217,15 +205,15 @@ IssuePfx - COMException: System.Runtime.InteropServices.COMException (0x80094015
 
 #### Cause - Certificate enrollment policy server name
 
-This issue occurs if the computer that hosts the Intune NDES Connector can't locate a certificate enrollment policy server.
+This issue occurs if the computer that hosts the Intune PKCS Connector can't locate a certificate enrollment policy server.
 
 **Resolution**:
 
-Manually configure the name of the certificate enrollment policy server on the computer that hosts the NDES connector. To configure the name, use the [Add-CertificateEnrollmentPolicyServer](/powershell/module/pkiclient/add-certificateenrollmentpolicyserver?view=win10-ps&preserve-view=true) PowerShell cmdlet.
+Manually configure the name of the certificate enrollment policy server on the computer that hosts the Intune PKCS Connector. To configure the name, use the [Add-CertificateEnrollmentPolicyServer](/powershell/module/pkiclient/add-certificateenrollmentpolicyserver?view=win10-ps&preserve-view=true) PowerShell cmdlet.
 
 ### The submission is pending
 
-After you deploy a PKCS certificate profile to mobile devices, the certificates aren't acquired, and the NDESConnector log contains the string **The submission is pending**, as seen in the following example:
+After you deploy a PKCS certificate profile to mobile devices, the certificates aren't acquired, and the NDESConnector_date_time.svclog log contains the string **The submission is pending**, as seen in the following example:
 
 ```
 IssuePfx - The submission is pending: Taken Under Submission
@@ -250,7 +238,7 @@ Edit the Policy Module properties to set: **Follow the settings in the certifica
 
 ### The parameter is incorrect 0x80070057
 
-With the Intune Certificate Connector installed and configured successfully, devices don't receive PKCS certificates and the NDESConnector log contains the string **The parameter is incorrect. 0x80070057**, as seen in the following example:
+With the Intune Certificate Connector installed and configured successfully, devices don't receive PKCS certificates and the NDESConnector_date_time.svclog log contains the string **The parameter is incorrect. 0x80070057**, as seen in the following example:
 
 ```
 CCertRequest::Submit: The parameter is incorrect. 0x80070057 (WIN32: 87 ERROR_INVALID_PARAMETER)
@@ -275,7 +263,7 @@ For more information, see [Configure and use PKCS certificates with Intune](../p
 
 ### Denied by Policy Module
 
-When devices receive the trusted root certificate but don’t receive the PFX certificate and the NDESConnector log contains the string **The submission failed: Denied by Policy Module**, as seen in the following example:
+When devices receive the trusted root certificate but don’t receive the PFX certificate and the NDESConnector_date_time.svclog log contains the string **The submission failed: Denied by Policy Module**, as seen in the following example:
 
 ```
 IssuePfx - The submission failed: Denied by Policy Module
@@ -302,14 +290,14 @@ For more information, see [Configure certificate templates on the CA](../protect
 
 ### Certificate profile stuck as Pending
 
-In the Microsoft Endpoint Manager admin center, PKCS certificate profiles fail to deploy with a state of **Pending**. There are no obvious errors in the NDESConnector log file.
+In the Microsoft Endpoint Manager admin center, PKCS certificate profiles fail to deploy with a state of **Pending**. There are no obvious errors in the NDESConnector_date_time.svclog log file.
 Because the cause of this problem isn’t identified clearly in logs, work through the following causes.
 
 #### Cause 1 - Unprocessed request files
 
 Review the request files for errors that indicate why they failed to be processed.
 
-1. On the computer that hosts the NDES connector, use File Explorer to navigate to **%programfiles%\Microsoft Intune\PfxRequest**.
+1. On the server that hosts the Intune PKCS Connector, use File Explorer to navigate to **%programfiles%\Microsoft Intune\PfxRequest**.
 2. Review files in the **Failed** and **Processing** folders, using your favorite text editor.
 
    > [!div class="mx-imgBorder"]

--- a/memdocs/intune/protect/troubleshoot-pkcs-certificate-profiles.md
+++ b/memdocs/intune/protect/troubleshoot-pkcs-certificate-profiles.md
@@ -84,11 +84,11 @@ Log files for these roles include Windows Event Viewer, Certificate consoles, an
 
   Related registry key: *HKLM\SW\Microsoft\MicrosoftIntune\NDESConnector\ConnectionStatus*
 
-  Location: On the server that hosts the Intune PKCS Connector at *%program_files%\Microsoft intune\ndesconnectorsvc\logs\logs*
+  Location: On the server that hosts the Intune Certificate Connector at *%program_files%\Microsoft intune\ndesconnectorsvc\logs\logs*
 
 - **Windows Application log**:
 
-  Location: On the server that hosts the Intune PKCS Connector: Run **eventvwr.msc** to open Windows Event Viewer
+  Location: On the server that hosts the Intune Certificate Connector: Run **eventvwr.msc** to open Windows Event Viewer
 
 ### Logs for Android devices
 
@@ -124,9 +124,9 @@ On the device, open **Event Viewer** > **Applications and Services Logs** > **Mi
 
 ## Antivirus exclusions
 
-Consider adding Antivirus exclusions on servers that host the Intune PKCS Connector when:
+Consider adding Antivirus exclusions on servers that host the Intune Certificate Connector when:
 
-- Certificate requests reach the server or the Intune PKCS Connector, but are not successfully processed 
+- Certificate requests reach the server or the Intune Certificate Connector, but are not successfully processed 
 - Certificates are issued slowly
 
 The following are examples of locations that you might exclude:
@@ -205,11 +205,11 @@ IssuePfx - COMException: System.Runtime.InteropServices.COMException (0x80094015
 
 #### Cause - Certificate enrollment policy server name
 
-This issue occurs if the computer that hosts the Intune PKCS Connector can't locate a certificate enrollment policy server.
+This issue occurs if the computer that hosts the Intune Certificate Connector can't locate a certificate enrollment policy server.
 
 **Resolution**:
 
-Manually configure the name of the certificate enrollment policy server on the computer that hosts the Intune PKCS Connector. To configure the name, use the [Add-CertificateEnrollmentPolicyServer](/powershell/module/pkiclient/add-certificateenrollmentpolicyserver?view=win10-ps&preserve-view=true) PowerShell cmdlet.
+Manually configure the name of the certificate enrollment policy server on the computer that hosts the Intune Certificate Connector. To configure the name, use the [Add-CertificateEnrollmentPolicyServer](/powershell/module/pkiclient/add-certificateenrollmentpolicyserver?view=win10-ps&preserve-view=true) PowerShell cmdlet.
 
 ### The submission is pending
 
@@ -297,7 +297,7 @@ Because the cause of this problem isn’t identified clearly in logs, work throu
 
 Review the request files for errors that indicate why they failed to be processed.
 
-1. On the server that hosts the Intune PKCS Connector, use File Explorer to navigate to **%programfiles%\Microsoft Intune\PfxRequest**.
+1. On the server that hosts the Intune Certificate Connector, use File Explorer to navigate to **%programfiles%\Microsoft Intune\PfxRequest**.
 2. Review files in the **Failed** and **Processing** folders, using your favorite text editor.
 
    > [!div class="mx-imgBorder"]


### PR DESCRIPTION
The PKCS troubleshooting document still contained mentions to SCEP specific components such as NDES, however PKCS doesn't use NDES.  