### PR TITLE
Correct journalctl examples.

### DIFF
--- a/memdocs/intune/protect/microsoft-tunnel-monitor.md
+++ b/memdocs/intune/protect/microsoft-tunnel-monitor.md
@@ -43,15 +43,15 @@ For more information and command-line examples, see [mst-cli command-line tool f
 
 ## View Microsoft Tunnel logs
 
-Beginning in October 2020, Microsoft Tunnel logs information to the Linux server logs in the *syslog* format. You can view the log entries by using the **jouralctl -t** command followed by one or more tags that are specific to Microsoft Tunnel entries:
+Beginning in October 2020, Microsoft Tunnel logs information to the Linux server logs in the *syslog* format. You can view the log entries by using the **journalctl -t** command followed by one or more tags that are specific to Microsoft Tunnel entries:
 
 - **ocserv** -  Display server logs.
 - **mstunnel-agent**: Display agent logs.
 - **mstunnel_monitor**: Display monitoring task logs.
 
-For example, to view information for only the tunnel server, run `./journalctl -t ocserv`.  To view information for all three, you can run `./journalctl -t ocserv -t mstunnel-agent -t mstunnel_monitor`.
+For example, to view information for only the tunnel server, run `journalctl -t ocserv`.  To view information for all three, you can run `journalctl -t ocserv -t mstunnel-agent -t mstunnel_monitor`.
 
-You can add  `-f` to the command to display an active and continuing view of the log file.   For example, to actively monitor ongoing processes for Microsoft Tunnel, run `./journalctl -t mstunnel_monitor -f`.
+You can add  `-f` to the command to display an active and continuing view of the log file.   For example, to actively monitor ongoing processes for Microsoft Tunnel, run `journalctl -t mstunnel_monitor -f`.
 
 Additional options for *journalctl*:
 


### PR DESCRIPTION
Current examples are misspelled or rely on journalctl to to be in the current working directory.

This PR fixes the examples.