### PR TITLE
Update Autopilot Redeployment/Reset Setting

### DIFF
--- a/memdocs/autopilot/windows-autopilot-reset.md
+++ b/memdocs/autopilot/windows-autopilot-reset.md
@@ -82,7 +82,7 @@ You can set the policy using one of these methods:
    - **Platform** = **Windows 10 or later**
    - **Profile type** = **Device restrictions**
    - **Category** = **General**
-   - **Automatic Redeployment** = **Allow**. Deploy this setting to all devices where a local reset should be permitted.
+   - **Autopilot Reset** = **Allow**. Deploy this setting to all devices where a local reset should be permitted.
  - If you're using an MDM provider other than Intune, check your MDM provider documentation on how to set this policy. 
 
 - Windows Configuration Designer


### PR DESCRIPTION
The setting has been renamed within the Intune Device Restriction policy to "Autopilot Reset".  When customers are enabling this setting, they may not understand that it is actually enabling the local Autopilot reset option.