### PR TITLE
Update compliance-policy-create-windows.md

### DIFF
--- a/memdocs/intune/protect/compliance-policy-create-windows.md
+++ b/memdocs/intune/protect/compliance-policy-create-windows.md
@@ -172,7 +172,7 @@ Applies only to co-managed devices running Windows 10 and later. Intune-only dev
    [DeviceStatus CSP - DeviceStatus/Compliance/EncryptionCompliance](/windows/client-management/mdm/devicestatus-csp)
 
   > [!NOTE]
-  > The **Encryption of data storage on a device** setting generically checks for the presence of encryption on the device, more specifically at the OS drive level. For a more robust encryption setting, consider using **Require BitLocker**, which leverages Windows Device Health Attestation to validate Bitlocker status at the TPM level.
+  > The **Encryption of data storage on a device** setting generically checks for the presence of encryption on the device, more specifically at the OS drive level. And currently we only support the encryption check with BitLocker. For a more robust encryption setting, consider using **Require BitLocker**, which leverages Windows Device Health Attestation to validate Bitlocker status at the TPM level.
 
 ### Device Security  
 

--- a/memdocs/intune/protect/compliance-policy-create-windows.md
+++ b/memdocs/intune/protect/compliance-policy-create-windows.md
@@ -172,7 +172,7 @@ Applies only to co-managed devices running Windows 10 and later. Intune-only dev
    [DeviceStatus CSP - DeviceStatus/Compliance/EncryptionCompliance](/windows/client-management/mdm/devicestatus-csp)
 
   > [!NOTE]
-  > The **Encryption of data storage on a device** setting generically checks for the presence of encryption on the device, more specifically at the OS drive level. And currently we only support the encryption check with BitLocker. For a more robust encryption setting, consider using **Require BitLocker**, which leverages Windows Device Health Attestation to validate Bitlocker status at the TPM level.
+  > The **Encryption of data storage on a device** setting generically checks for the presence of encryption on the device, more specifically at the OS drive level. Currently, Intune supports only the encryption check with BitLocker. For a more robust encryption setting, consider using **Require BitLocker**, which leverages Windows Device Health Attestation to validate Bitlocker status at the TPM level.
 
 ### Device Security  
 


### PR DESCRIPTION
We have test and confirmed when we try to check with EncryptionCompliance status from Windows 10 devices, we will only check with  Win32_EncryptableVolume , and this WMI only support with BitLocker, as you may check in https://docs.microsoft.com/en-us/windows/win32/secprov/win32-encryptablevolume , so it means our "Encryption of data storage on a device" check in Compliance may only support with BitLocker Encryption, if we do not state this clearly, customer may be confused and request us why the 3rd party encryption status cannot be detected