### PR TITLE
MDM authority blade is not present anymore

### DIFF
--- a/memdocs/intune/fundamentals/mdm-authority-set.md
+++ b/memdocs/intune/fundamentals/mdm-authority-set.md
@@ -99,7 +99,7 @@ To enable coexistence, you must add Intune as the MDM authority for your environ
 
 1. Sign in to endpoint.microsoft.com with Azure AD Global or Intune service administrator rights.
 2. Navigate to **Devices**.
-3. The **Add MDM Authority blade** displays.
+
 4. To switch the MDM authority from *Office 365* to *Intune* and enables coexistence, select **Intune MDM Authority** > **Add**.
   ![Screenshot of Add MDM Authority screen](./media/mdm-authority-set/add-mdm-authority.png)
 


### PR DESCRIPTION
I am a global admin and cannot find any blade to set intune as MDM authority.

When I check MDM authority in Tenant administration, it says "MDM for Office 365"