### PR TITLE
Bitlocker management is supported over CMG in 2010

### DIFF
--- a/memdocs/configmgr/core/clients/manage/cmg/supported-configurations.md
+++ b/memdocs/configmgr/core/clients/manage/cmg/supported-configurations.md
@@ -51,6 +51,7 @@ The following table lists CMG support for Configuration Manager features:
 | Software distribution (device-targeted) | ![Supported](media/green_check.png) |
 | Software distribution (user-targeted, required)<br>(with Azure AD integration) | ![Supported](media/green_check.png) |
 | Software distribution (user-targeted, available)<br>([all requirements](../../../../apps/deploy-use/deploy-applications.md#deploy-user-available-applications)) | ![Supported](media/green_check.png) |
+| BitLocker Management | ![Supported](media/green_check.png) (2010) |
 | Windows 10 [in-place upgrade task sequence](../../../../osd/deploy-use/create-a-task-sequence-to-upgrade-an-operating-system.md) <sup>[Note&nbsp;2](#bkmk_note2)</sup> | ![Supported](media/green_check.png) |
 | Task sequence without a boot image, deployed with the option to **Download all content locally before starting task sequence** <sup>[Note&nbsp;2](#bkmk_note2)</sup> | ![Supported](media/green_check.png) |
 | Task sequence without a boot image, deployed with [either download option](../../../../osd/deploy-use/deploy-task-sequence-over-internet.md#deploy-windows-10-in-place-upgrade-via-cmg) <sup>[Note&nbsp;2](#bkmk_note2)</sup> | ![Supported](media/green_check.png) (1910) |
@@ -67,7 +68,6 @@ The following table lists CMG support for Configuration Manager features:
 | macOS clients | ![Not supported](media/Red_X.png) |
 | Peer cache | ![Not supported](media/Red_X.png) |
 | On-premises MDM | ![Not supported](media/Red_X.png) |
-| BitLocker Management | ![Not supported](media/Red_X.png) |
 | Alternate content providers | ![Not supported](media/Red_X.png) |
 
 |Key|


### PR DESCRIPTION
From What's new in ConfigMgr 2010 page:

"You can now manage BitLocker policies and escrow recovery keys over a cloud management gateway (CMG). This change also provides support for BitLocker management via internet-based client management (IBCM). There's no change to the setup process for BitLocker management. This improvement supports domain-joined and hybrid domain-joined devices."

I understand that this means that Bitlocker mgmt is supported via CMG in 2010! :-)