### PR TITLE
Update wi-fi-profile-shared-key.md

### DIFF
--- a/memdocs/intune/configuration/wi-fi-profile-shared-key.md
+++ b/memdocs/intune/configuration/wi-fi-profile-shared-key.md
@@ -121,7 +121,7 @@ The following example includes the XML code for an Android or Windows Wi-Fi prof
 ``` xml
 <!--
 <hex>53534944</hex> = The hexadecimal value of <name><SSID of wifi profile></name>
-<Name of wifi profile> = Name of profile shown to users. It could be <name>Your Company's Network</name>.
+<Name of wifi profile> = Name of profile shown to users. For example, enter <name>ContosoWiFi</name>.
 <SSID of wifi profile> = Plain text of SSID. Does not need to be escaped. It could be <name>Your Company's Network</name>.
 <nonBroadcast><true/false></nonBroadcast>
 <Type of authentication> = Type of authentication used by the network, such as WPA2PSK.
@@ -261,7 +261,9 @@ You can also create an XML file from an existing Wi-Fi connection. On a Windows 
 
         `key=clear` exports the key in plain text, which is required to successfully use the profile.
         
-    - If the exported Wi-Fi profile `<name></name>` element includes a space, then it returns a syncml 500 error when assigned. To resolve the error, remove the space.
+    - If the exported Wi-Fi profile `<name></name>` element includes a space, then it might return a `ERROR CODE 0x87d101f4 ERROR DETAILS Syncml(500)` error when assigned. When this issue happens, the profile is listed in `\ProgramData\Microsoft\Wlansvc\Profiles\Interfaces`, and shows as a known network. But, it doesn't successfully display as managed policy in the "Areas managed by..." URI.
+    
+      To resolve this issue, remove the space.
 
 After you have the XML file, copy and paste the XML syntax into OMA-URI settings > **Data type**. [Create a custom profile](#create-a-custom-profile) (in this article) lists the steps.
 

--- a/memdocs/intune/configuration/wi-fi-profile-shared-key.md
+++ b/memdocs/intune/configuration/wi-fi-profile-shared-key.md
@@ -7,7 +7,7 @@ keywords:
 author: MandiOhlinger
 ms.author: mandia
 manager: dougeby
-ms.date: 11/11/2020
+ms.date: 01/06/2021
 ms.topic: how-to
 ms.service: microsoft-intune
 ms.subservice: configuration
@@ -261,7 +261,7 @@ You can also create an XML file from an existing Wi-Fi connection. On a Windows 
 
         `key=clear` exports the key in plain text, which is required to successfully use the profile.
         
-    - If the exported Wi-Fi profile <name></name> element contains a space it will produce a syncml 500 error when assigned. Removing the space will allow WiFi policy to be successfully managed.
+    - If the exported Wi-Fi profile `<name></name>` element includes a space, then it returns a syncml 500 error when assigned. To resolve the error, remove the space.
 
 After you have the XML file, copy and paste the XML syntax into OMA-URI settings > **Data type**. [Create a custom profile](#create-a-custom-profile) (in this article) lists the steps.
 

--- a/memdocs/intune/configuration/wi-fi-profile-shared-key.md
+++ b/memdocs/intune/configuration/wi-fi-profile-shared-key.md
@@ -260,6 +260,8 @@ You can also create an XML file from an existing Wi-Fi connection. On a Windows 
         `netsh wlan export profile name="YourProfileName" key=clear folder=c:\Wifi`
 
         `key=clear` exports the key in plain text, which is required to successfully use the profile.
+        
+    - If the exported Wi-Fi profile <name></name> element contains a space it will produce a syncml 500 error when assigned. Removing the space will allow WiFi policy to be successfully managed.
 
 After you have the XML file, copy and paste the XML syntax into OMA-URI settings > **Data type**. [Create a custom profile](#create-a-custom-profile) (in this article) lists the steps.
 


### PR DESCRIPTION
A space is expected to be permitted within XML elements, as per the WLAN_profile Schema and does not present issues with rasphone.exe created or GPO profiles. However, an exported profile containing a space in the <name></name> element will cause a syncml 500 error when assigned. (MEM console error 0x87d101f4 and 0x800700b7 via Kusto) Although the profile is available in C:\ProgramData\Microsoft\Wlansvc\Profiles\Interfaces and shows as a known network, it does not successfully display as managed policy in the "Areas managed by..." URI. In addition to the note it may be helpful to ensure the two examples are consistent in approach. The EAP-based Wi-Fi profile example,  <name>testcert</name> is preferred over the XML example </name><Name of wifi profile> = Name of profile shown to users. It could be <name>Your Company's Network</name>.