### PR TITLE
Consistent platform properties section

### DIFF
--- a/memdocs/intune/protect/certificates-pfx-configure.md
+++ b/memdocs/intune/protect/certificates-pfx-configure.md
@@ -163,6 +163,15 @@ Before you begin, [review requirements for the connector](certificate-connectors
 
 3. Enter the following properties:
    - **Platform**: Choose the platform of the devices that will receive this profile.
+     - Android device administrator
+     - Android Enterprise:
+       - Fully Managed
+       - Dedicated
+       - Corporate-Owned Work Profile
+       - Personally-Owned Work Profile
+     - iOS/iPadOS
+     - macOS
+     - Windows 10 and later
    - **Profile**: Select **Trusted certificate**
 
 4. Select **Create**.


### PR DESCRIPTION
As a new user to Intune following this documentation, I didn't realize that I needed to select Android Personally-Owned Work Profile specifically when creating the trusted certificate profile leading to me opening a support case with Microsoft. This change copies the text from the PKCS section further down the page to make it consistent within the document.