### PR TITLE
Both site servers need Full control permissions to System - System Ma…

### DIFF
--- a/memdocs/configmgr/core/servers/deploy/configure/site-server-high-availability.md
+++ b/memdocs/configmgr/core/servers/deploy/configure/site-server-high-availability.md
@@ -54,7 +54,9 @@ Microsoft Core Services Engineering and Operations used this feature to migrate 
     > - [Azure virtual machines (for cloud-based infrastructure)](../../../understand/use-cloud-services.md#azure-virtual-machines-for-cloud-based-infrastructure)
     > - [FAQ for Configuration Manager on Azure](../../../understand/configuration-manager-on-azure.md)  
 
-- Both site servers must be joined to the same Active Directory domain.  
+- Both site servers must be joined to the same Active Directory domain.
+
+- Both site servers must be have **Full Control** permissions to Active Directory's **System - System Management** container and all descendant objects. 
 
 - Configuration Manager supports site servers in passive mode in a hierarchy. The central administration site and child primary sites can have an additional site server in passive mode.<!-- 3607755 -->  
 


### PR DESCRIPTION
…nagement container

Both site servers need Full control permissions to Active Directory's System - System Management container. The 1st site server already has it, but the permissions need to be added to the passive site server.