### PR TITLE
App groups cannot be used in TS

### DIFF
--- a/memdocs/configmgr/apps/deploy-use/create-app-groups.md
+++ b/memdocs/configmgr/apps/deploy-use/create-app-groups.md
@@ -59,7 +59,7 @@ To troubleshoot an app group deployment, use the following log files on the clie
 - *Version 1906*: Apps in the group can only contain **Windows Installer** or **Script** deployment types.
   - *Version 1906*: Set the deployment type installation behavior to **Install for system**.
 - The following deployment options may not work: alerts, approval, phased deployment, repair.
-- You can't use Application groups with **Install Application** task sequence step.
+- You can't use application groups with the **Install Application** task sequence step.
 - You can't export or import app groups.
 - Don't include in the group any apps that require restart, or the group deployment may fail.
 - *Version 1906*: You can't deploy the app group to a user collection.

--- a/memdocs/configmgr/apps/deploy-use/create-app-groups.md
+++ b/memdocs/configmgr/apps/deploy-use/create-app-groups.md
@@ -59,6 +59,7 @@ To troubleshoot an app group deployment, use the following log files on the clie
 - *Version 1906*: Apps in the group can only contain **Windows Installer** or **Script** deployment types.
   - *Version 1906*: Set the deployment type installation behavior to **Install for system**.
 - The following deployment options may not work: alerts, approval, phased deployment, repair.
+- You can't use Application groups with **Install Application** task sequence step.
 - You can't export or import app groups.
 - Don't include in the group any apps that require restart, or the group deployment may fail.
 - *Version 1906*: You can't deploy the app group to a user collection.


### PR DESCRIPTION
I added a new known issue that you can use application groups with Install Application task sequence step.