### PR TITLE
Adding information about iOS User enrollment

### DIFF
--- a/memdocs/intune/enrollment/enrollment-restrictions-set.md
+++ b/memdocs/intune/enrollment/enrollment-restrictions-set.md
@@ -170,9 +170,9 @@ By default, Intune classifies iOS/iPadOS devices as personally-owned. To be clas
 - [Registered with a serial number](corporate-identifiers-add.md).
 - Enrolled by using Automated Device Enrollment (formerly Device Enrollment Program)
 
->[!NOTE]
->In case you have configured iOS User Enrollment Profile, it will override enrollment restriction policy.
-https://docs.microsoft.com/en-us/mem/intune/enrollment/ios-user-enrollment
+> [!NOTE]
+> An iOS User Enrollment profile overrides an enrollment restriction policy. For more information, see [Set up iOS/iPadOS and iPadOS User Enrollment (preview)](ios-user-enrollment.md).
+>
 
 
 ## Change enrollment restriction priority

--- a/memdocs/intune/enrollment/enrollment-restrictions-set.md
+++ b/memdocs/intune/enrollment/enrollment-restrictions-set.md
@@ -170,6 +170,10 @@ By default, Intune classifies iOS/iPadOS devices as personally-owned. To be clas
 - [Registered with a serial number](corporate-identifiers-add.md).
 - Enrolled by using Automated Device Enrollment (formerly Device Enrollment Program)
 
+>[!NOTE]
+>In case you have configured iOS User Enrollment Profile, it will override enrollment restriction policy.
+https://docs.microsoft.com/en-us/mem/intune/enrollment/ios-user-enrollment
+
 
 ## Change enrollment restriction priority
 


### PR DESCRIPTION
I am adding Notes to explain the combination of iOS user enrollment profile and Blocking personal device enrollment restrictions.