### PR TITLE
Update ios-user-enrollment-supported-actions.md

### DIFF
--- a/memdocs/intune/enrollment/ios-user-enrollment-supported-actions.md
+++ b/memdocs/intune/enrollment/ios-user-enrollment-supported-actions.md
@@ -115,6 +115,7 @@ The following options aren't supported on devices enrolled with User Enrollment.
 ## Known issues in preview
 - VPP license revocation: A notification that the license has been revoked does not appear. The current behavior is that the revocation is successful, but the end user is not notified. 
 - VPP application reporting: In the report located at Client Apps > Apps > [App Name] > Device Install Status, VPP applications deployed to User Enrolled devices are reporting as "failed", even when the application successfully deploys to the device. 
+- VPP License Assignment: If the VPP license is already associated with the AppleID, or the user has another device enrolled with Device Enrollment, the license will associate to the AppleID successfully. However, if the only iOS device the user has enrolled is User Enrolled, the VPP license assignment will fail and install will fail with **Can't Find VPP License For App** (0x87D13B95). Re-enrolling the device with Device Enrollment to allow the assignment then re-enrolling again as User Enrollment resolves the assignment.
 - Application reporting: For app types unsupported with User Enrollment, reports may provide irrelevant error messages. 
 - Company Portal app experience: Users see all applications targeted to them, regardless of whether those application types are supported for User Enrolled devices. 
 - Company Portal app experience: Users see the same text indicating what organizations can see for User and Device Enrollment if the admin has customized the text indicating what organizations can't see.


### PR DESCRIPTION
I've been instructed to document the issue here. Results of multiple attempts at assigning VPP apps. Each time, the ones assigned during the previous user enrollment would work in future enrollments after passing by device enrollment, but newly targeted apps on user-enrolled device never stop throwing error. As far as I can tell, Company Portal can't pull the configured AppleID across the sandbox barrier. Never was able to get the data I needed to validate this is the issue but I suspect Intune isn't providing associateClientUserIdStrs property when doing manageVPPLicensesByAdamIdSrv per https://developer.apple.com/business/documentation/MDM-Protocol-Reference.pdf pg159. It'd be nice if we could see the result of the Intune<>Vpp traffic somewhere, or maybe I just don't know where to look.