### PR TITLE
Add extra known issue for GPO enrollment in ESP scenario

### DIFF
--- a/memdocs/intune/enrollment/windows-enrollment-status.md
+++ b/memdocs/intune/enrollment/windows-enrollment-status.md
@@ -179,6 +179,7 @@ The following are known issues related to the Enrollment Status Page.
 - When the DeviceLock policy (https://docs.microsoft.com/windows/client-management/mdm/policy-csp-devicelock) is enabled as part of an ESP profile, the OOBE or user desktop autologon could fail unexpectantly for two reasons.
   - If the device didn't reboot before exiting the ESP Device setup phase, the user may be prompted to enter their Azure AD credentials. This prompt occurs instead of a successful autologon where the user sees the Windows first login animation.
   - The autologon will fail if the device rebooted after the user entered their Azure AD credentials but before exiting the ESP Device setup phase. This failure occurs because the ESP Device setup phase never completed. The workaround is to reset the device.
+- Windows device enrolled via GPO(Group Policy) is not applicable for ESP.
 
 ## Next steps
 

--- a/memdocs/intune/enrollment/windows-enrollment-status.md
+++ b/memdocs/intune/enrollment/windows-enrollment-status.md
@@ -179,7 +179,7 @@ The following are known issues related to the Enrollment Status Page.
 - When the DeviceLock policy (https://docs.microsoft.com/windows/client-management/mdm/policy-csp-devicelock) is enabled as part of an ESP profile, the OOBE or user desktop autologon could fail unexpectantly for two reasons.
   - If the device didn't reboot before exiting the ESP Device setup phase, the user may be prompted to enter their Azure AD credentials. This prompt occurs instead of a successful autologon where the user sees the Windows first login animation.
   - The autologon will fail if the device rebooted after the user entered their Azure AD credentials but before exiting the ESP Device setup phase. This failure occurs because the ESP Device setup phase never completed. The workaround is to reset the device.
-- ESP doesn't apply to a Windows device that was enrolled via Group Policy (GPO).
+- ESP doesn't apply to a Windows device that was enrolled with Group Policy (GPO).
 
 ## Next steps
 

--- a/memdocs/intune/enrollment/windows-enrollment-status.md
+++ b/memdocs/intune/enrollment/windows-enrollment-status.md
@@ -179,7 +179,7 @@ The following are known issues related to the Enrollment Status Page.
 - When the DeviceLock policy (https://docs.microsoft.com/windows/client-management/mdm/policy-csp-devicelock) is enabled as part of an ESP profile, the OOBE or user desktop autologon could fail unexpectantly for two reasons.
   - If the device didn't reboot before exiting the ESP Device setup phase, the user may be prompted to enter their Azure AD credentials. This prompt occurs instead of a successful autologon where the user sees the Windows first login animation.
   - The autologon will fail if the device rebooted after the user entered their Azure AD credentials but before exiting the ESP Device setup phase. This failure occurs because the ESP Device setup phase never completed. The workaround is to reset the device.
-- Windows device enrolled via GPO(Group Policy) is not applicable for ESP.
+- ESP doesn't apply to a Windows device that was enrolled via Group Policy (GPO).
 
 ## Next steps
 


### PR DESCRIPTION
According to https://portal.microsofticm.com/imp/v3/incidents/details/214735469/home 
"What is happening here (and what Britini was referring to earlier) is that the method by which the customer is enrolling devices (Group Policy) will never allow ESP to run, meaning it will never be marked completed. However, because the customer wants ESP to be enabled regardless, the policy enabling ESP reaches the machine and stays there even though ESP will not ever run.
When the Sidecar agent runs, it looks at the ESP policy and sees that it is enabled (even though ESP has not ever and will never run on the machine) so Sidecar will wait indefinitely for ESP to be marked completed in order to provision any apps not on the ESP blocking list that is configured in the ESP profile. However, ESP will never be marked completed because it will never run, thus the apps are never provisioned. This is all by design."
Suggest to add this into doc for other customers can notice it