### PR TITLE
Added Note in Internal network registration

### DIFF
--- a/memdocs/configmgr/core/clients/deploy/deploy-clients-cmg-token.md
+++ b/memdocs/configmgr/core/clients/deploy/deploy-clients-cmg-token.md
@@ -43,6 +43,9 @@ This method requires the client to first register with the management point on t
 
 The site enables this behavior by default.
 
+> [!NOTE]
+> In HTTPS management point, the client must present a valid PKI issued cert, or an AAD token, or a bulk registration token to first register regardless of internet/intranet management point.
+
 ## Bulk registration token
 
 If you can't install and register clients on the internal network, create a bulk registration token. Use this token when the client installs on an internet-based device, and registers through the CMG. The bulk registration token has a short-validity period, and isn't stored on the client or the site. It allows the client to generate a unique token, which paired with its self-signed certificate, lets it authenticate with the CMG.

--- a/memdocs/configmgr/core/clients/deploy/deploy-clients-cmg-token.md
+++ b/memdocs/configmgr/core/clients/deploy/deploy-clients-cmg-token.md
@@ -2,7 +2,7 @@
 title: Token-based authentication for CMG
 titleSuffix: Configuration Manager
 description: Register a client on the internal network for a unique token or create a bulk registration token for internet-based devices.
-ms.date: 08/17/2020
+ms.date: 03/05/2021
 ms.prod: configuration-manager
 ms.technology: configmgr-client
 ms.topic: conceptual
@@ -44,7 +44,7 @@ This method requires the client to first register with the management point on t
 The site enables this behavior by default.
 
 > [!NOTE]
-> In HTTPS management point, the client must present a valid PKI issued cert, or an AAD token, or a bulk registration token to first register regardless of internet/intranet management point.
+> With an HTTPS management point, the client needs to first register regardless of internet/intranet management point. The client needs to present a valid PKI-issued certificate, an Azure AD token, or a bulk registration token.
 
 ## Bulk registration token
 


### PR DESCRIPTION
this official statement is misleading that users can register CM client without bulk when machines connect to any intra MP (HP/EHTTP/HTTPS).
I want to suggest to add note to this article.