### PR TITLE
Adding WAV as supported Audio file

### DIFF
--- a/memdocs/intune/fundamentals/end-user-mam-apps-android.md
+++ b/memdocs/intune/fundamentals/end-user-mam-apps-android.md
@@ -75,7 +75,7 @@ Download this app from the Google Play store.
 
 The following file types are supported:
 
-* **Audio:** AAC LC, HE-AACv1 (AAC+), HE-AACv2 (enhanced AAC+), AAC ELD (enhanced low delay AAC), AMR-NB, AMR-WB, FLAC, MP3, MIDI, Ogg Vorbis
+* **Audio:** AAC LC, HE-AACv1 (AAC+), HE-AACv2 (enhanced AAC+), AAC ELD (enhanced low delay AAC), AMR-NB, AMR-WB, FLAC, MP3, MIDI, Ogg Vorbis, WAV
 * **Video:** H.263, H.264 AVC, MPEG-4 SP, VP8
 * **Image:** .jpg, .pjpg, .png, .ppng, .bmp, .pbmp, .gif, .pgif, .jpeg, .pjpeg
 * **Documents:** PDF, PPDF


### PR DESCRIPTION
As per this "Completed" comment in User Voice (https://microsoftintune.uservoice.com/forums/291681-ideas/suggestions/12403098-support-playing-wav-files-in-outlook) the AIP App now does WAV files and this works seemlessly when listening to voicemails in emails on MAM protected Android devices.