### PR TITLE
Help me Win Online Arguments about Client Cache

### DIFF
--- a/memdocs/configmgr/core/clients/manage/manage-clients.md
+++ b/memdocs/configmgr/core/clients/manage/manage-clients.md
@@ -259,7 +259,7 @@ If the client attempts to download content that's less than the size of the cach
 
 If you later increase the cache size, the client attempts to download the content again during the next retry interval. The client tries to download the content every four hours until it tries 18 times.  
 
-Cached content isn't automatically deleted. It remains in the cache for at least one day after the client uses that content. If you configure the content with the option to persist content in the client cache, the client doesn't automatically delete it. If the cache space is used by content that was downloaded within the last 24 hours, and the client must download new content, either increase the cache size or choose the option to delete persisted cache content.
+Cached content isn't automatically deleted and is only removed if new content requires its disk space. It remains in the cache for the configured number of minutes after the client uses that content. If you configure the content with the option to persist content in the client cache, the client doesn't automatically delete it. If the cache space is used by content that was downloaded within the configured number of minutes, and the client must download new content, either increase the cache size or choose the option to delete persisted cache content. For more information see [About client settings in Configuration Manager](../deploy/about-client-settings.md#minimum-duration-before-cached-content-can-be-removed-minutes).
 
 For applications only, if the content for a related deployment currently exists in the cache, then the client downloads only new or changed files. Related deployments include those for older revisions of the same deployment type and superseded applications.
 


### PR DESCRIPTION
... cause let's be honest.  That's why we edit docs ... is it not?

It's long been my understanding that there is no mechanism within ConfigMgr that removes items from the client cache 'just because'.  You set the cache size, the client fills the cache to that size as it download content, and from that point on only removes items if it needs room in the cache to download new content.  Which is to say: that within reason the cache will hover around the configured max value over time. Fluctuating because the items removed might be larger that the new items coming in.  So many orgs have implemented their own 'maintenance' solutions to this 'problem' that people have started just assuming that's how the product works instead of something someone put in their environment years ago.

This doc _kind_ of hinted at that but not clearly enough to earn me street cred on Reddit.  Wait ...  I mean ... to properly aid users in understanding and using the product.  Yea, that's it.

Though, lest you think I'm just in it for the 'gram: I updated the doc to reflect the functionality added in 1906 (now out of support) that made the cache tombstone value configurable.  It's no longer hard-coded at 24 hours like this doc originally stated.

I suck at the English language (as well as every other language humans have invented) so please feel free to wordsmith as you desire.  As long as I still win.  Crap, I did it again. I mean, as long as clarity and great justice is brought to mankind.