### PR TITLE
Misleading description of the term "Offline". More distinction needs to be made to give the reader a better understanding of the term "Offline" with regards to Store for Business apps

### DIFF
--- a/memdocs/intune/apps/store-apps-company-portal-autopilot.md
+++ b/memdocs/intune/apps/store-apps-company-portal-autopilot.md
@@ -37,7 +37,7 @@ To manage devices and install apps, your users can use the Company Portal app. Y
 
 For Windows 10 Autopilot provisioned devices, it is recommended that you associate your Microsoft Store for Business account with Intune. For more information, see [How to manage volume purchased apps from the Microsoft Store for Business with Microsoft Intune](windows-store-for-business.md).
 
-You can choose to install the **Company Portal (Offline)** app using the steps below. The Company Portal app will be installed in device context when assigned to the Autopilot group and will be installed on the device before the user logs in. ~~Offline apps are managed by Intune, whereas online apps are managed by the store. Use offline apps when you need to install and maintain a specific app version.~~
+You can choose to install the **Company Portal (Offline)** app using the steps below. The Company Portal app will be installed in device context when assigned to the Autopilot group and will be installed on the device before the user logs in. Offline apps are updated using Intune, whereas online apps are updated by the store. Use offline apps when you need to install and maintain a specific app version.
 
 ## Configure the store settings to show the offline app
 

--- a/memdocs/intune/apps/store-apps-company-portal-autopilot.md
+++ b/memdocs/intune/apps/store-apps-company-portal-autopilot.md
@@ -37,7 +37,7 @@ To manage devices and install apps, your users can use the Company Portal app. Y
 
 For Windows 10 Autopilot provisioned devices, it is recommended that you associate your Microsoft Store for Business account with Intune. For more information, see [How to manage volume purchased apps from the Microsoft Store for Business with Microsoft Intune](windows-store-for-business.md).
 
-You can choose to install the **Company Portal (Offline)** app using the steps below. The Company Portal app will be installed in device context when assigned to the Autopilot group and will be installed on the device before the user logs in. Offline apps are managed by Intune, whereas online apps are managed by the store. Use offline apps when you need to install and maintain a specific app version.
+You can choose to install the **Company Portal (Offline)** app using the steps below. The Company Portal app will be installed in device context when assigned to the Autopilot group and will be installed on the device before the user logs in. ~~Offline apps are managed by Intune, whereas online apps are managed by the store. Use offline apps when you need to install and maintain a specific app version.~~
 
 ## Configure the store settings to show the offline app
 


### PR DESCRIPTION
"Offline" apps can be regarded in two different contexts and I think a distinction needs to be made. Offline "Licensing" and Offline "Package deployment".
This article includes instructions for adding the Offline Company Portal app to Intune to distribute to Devices. The article context is for "Offline licensing". This means a valid license is not checked when the app is installed. This type of deployment is commonly, but not exclusively, used during Autopilot. During Autopilot, there is an increased chance of failure if, during the ESP, the device is required to check the Microsoft Store for Business for a valid license for an "Online" Store for Business app. Highlighting this would be beneficial to the reader.

The other context, which this article does not cover but the where the wording is misleading, is Offline "Package Deployment" for Store apps. This method requires an admin to download the offline package from the Store for Business to then distribute with Intune. This method is used if an admin wants to deploy a specific version of the Store app. Once the app is deployed it is then kept up-to-date as part of the normal application update cycle for all Store apps in Windows - it does not remain at the version deployed indefinitely - something the excerpt below could be seen to suggest":-

"Offline apps are managed by Intune, whereas online apps are managed by the store. Use offline apps when you need to install and maintain a specific app version".

Making a distinction between the two different contexts for "Offline" would clear up any confusion for deploying Store for Business apps with Intune.