### PR TITLE
Update pre-provision.md

### DIFF
--- a/memdocs/autopilot/pre-provision.md
+++ b/memdocs/autopilot/pre-provision.md
@@ -124,6 +124,9 @@ If the pre-provisioning process completed successfully and the device was reseal
 - If using Hybrid Azure AD Join, the device will reboot; after the reboot, enter the user’s Active Directory credentials.
 - Additional policies and apps will be delivered to the device, as tracked by the Enrollment Status Page (ESP). Once complete, the user will can access the desktop.
 
+>[!NOTE]
+>If the Microsoft Account Sign-In Assistant (wlidsvc) is disabled during the Technician Flow, the Azure AD sign in option may not show. Instead, users are asked to accept the EULA, and create a local account, which may not be what you want.
+
 ## Related topics
 
 [Pre-provisioning video](https://youtu.be/nE5XSOBV0rI)


### PR DESCRIPTION
Adding a note about disabling MSA preventing the User Flow from happening.

This information is already provided in the Device Restriction page: https://docs.microsoft.com/en-us/mem/intune/configuration/device-restrictions-windows-10#cloud-and-storage

If the behavior of the user flow isn't working as intended, there is a much higher chance admins will try to find out why in this page (or the Known Issue page) rather than searching through device restrictions (or even thinking about them being the cause)