### PR TITLE
Update advanced-threat-protection-configure.md

### DIFF
--- a/memdocs/intune/protect/advanced-threat-protection-configure.md
+++ b/memdocs/intune/protect/advanced-threat-protection-configure.md
@@ -3,7 +3,7 @@
 
 title: Configure Microsoft Defender for Endpoint in Microsoft Intune - Azure | Microsoft Docs
 description: Configure Microsoft Defender for Endpoint in Intune, including connecting to Defender for Endpoint, onboarding devices, assigning compliance for risk levels, and conditional access policies.
-keywords:
+keywords: configure, manage, capabilities, attack surface reduction, next-generation protection, security controls, endpoint detection and response, auto investigation and remediation, security controls, controls, microsoft defender for endpoint, mde
 author: brenduns 
 ms.author: brenduns
 manager: dougeby


### PR DESCRIPTION
I was working on rebranding in the m365 docset and ran across two duplicate pages that were rather light on concrete details about configuring Microsoft Defender for Endpoint. However, these pages come up prominently in the search results  for "microsoft defender for endpoint configure" on both Google and Bing, whereas this page is buried. If one or both of the duplicates are deleted, we still need a good, easy-to-find page for our users on this topic. Therefore, I copied the keyword metadata from the more visible, yet less useful, duplicates to this page.

The duplicates in the m365 repo, which I was asked to fix --
- https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/onboard?view=o365-worldwide
- https://docs.microsoft.com/en-us/microsoft-365/security/defender/onboard?view=o365-worldwide