### PR TITLE
Fixing the requirement of JSON data in the table

### DIFF
--- a/memdocs/intune/enrollment/android-samsung-knox-mobile-enroll.md
+++ b/memdocs/intune/enrollment/android-samsung-knox-mobile-enroll.md
@@ -73,14 +73,12 @@ When your company is successfully registered, you can create your MDM profile fo
 |Description        | No        |Enter text describing the Profile. |
 |MDM Information     | Yes        |Choose **Server URI not required for my MDM**.| 
 |MDM Agent APK      | Yes       |https://aka.ms/intune_kme| 
-|Custom JSON        | Yes*        |Leave this blank. |
+|Custom JSON        | No        |Leave this blank. |
 |Skip Setup wizard  | No        |Choose this option to skip standard device setup prompts for the end user.|
 |Allow End User to Cancel Enrollment | No | Choose this option to allow users to cancel KME.|
 | Privacy Policy, EULAs and Terms of Service | No | Leave this blank. |
 | Support contact details | Yes | Choose Edit to update your contact details |
 |Associate a Knox license with this profile | No | Leave this option unselected. Enrolling to Intune using KME doesn't require a Knox license.|
-
-\* This field is not required to complete profile creation in the Knox portal. However, Intune does require this field to be filled in so that the profile can successfully enroll the device in Intune.
 
 ### For Android Enterprise
 
@@ -93,12 +91,14 @@ For step-by-step guidance, see the [Samsung's Create Profile](https://docs.samsu
 |Pick your MDM | Yes | Choose Microsoft Intune. |
 |MDM Agent APK      | Yes       |https://aka.ms/intune_kme_deviceowner|
 |MDM Server URI     | No        |Leave this blank.|
-|Custom JSON Data        | No        |{"com.google.android.apps.work.clouddpc.EXTRA_ENROLLMENT_TOKEN": "Enter Intune enrollment token string"}. Learn how to create an enrollment token for [dedicated devices](android-kiosk-enroll.md) and [fully managed devices](android-fully-managed-enroll.md). |
+|Custom JSON Data        | Yes*        |{"com.google.android.apps.work.clouddpc.EXTRA_ENROLLMENT_TOKEN": "Enter Intune enrollment token string"}. Learn how to create an enrollment token for [dedicated devices](android-kiosk-enroll.md) and [fully managed devices](android-fully-managed-enroll.md). |
 |Dual DAR | No | Leave this blank.|
 |QR code for enrollment | No | You can add a QR code to speed enrollment.|
 |System applications | Yes | Choose the **Leave all system apps enabled** option to ensure all apps are enabled and available to the profile. If this option isn't selected, only a limited set of system apps displays in the device's apps tray. Apps such as the Email app remain hidden. |
 |Privacy Policy, EULAs and Terms of Service | No | Leave this blank.|
 |Company Name | Yes | This name will display during device enrollment. |
+
+\* This field is not required to complete profile creation in the Knox portal. However, Intune does require this field to be filled in so that the profile can successfully enroll the device in Intune.
 
 ## Add devices
 


### PR DESCRIPTION
I did submit a change that fixed the placement of the JSON data for Android enterprise but left the table set to 'yes' for required data on the device admin and 'no' on android enterprise. I swapped them as well so that it should be correct now.