### PR TITLE
Adding additional keyboard shortcuts for the Windows Company Portal

### DIFF
--- a/memdocs/intune/apps/company-portal-app.md
+++ b/memdocs/intune/apps/company-portal-app.md
@@ -228,6 +228,8 @@ The following keyboard shortcuts are available in the Windows Company Portal app
 |  | Remove | Ctrl+D or Delete |
 |  | Check access | Ctrl+M or F9 |
 | App details | Install | Ctrl+I |
+| App list tile | Install | Ctrl+I |
+| App list item | Install | Ctrl+I |
 | Devices | Available | Ctrl+D |
 
 End users will also be able to see the available shortcuts in the Windows Company Portal app.

--- a/memdocs/intune/apps/company-portal-app.md
+++ b/memdocs/intune/apps/company-portal-app.md
@@ -221,7 +221,7 @@ The following keyboard shortcuts are available in the Windows Company Portal app
 |  | Send feedback | Alt+F |
 |  | My profile | Alt+U |
 |  | Settings | Alt+T |
-| Home - Device tile | Rename | F2 |
+| Device tile | Rename | F2 |
 |  | Remove | Ctrl+D or Delete |
 |  | Check access | Ctrl+M or F9 |
 | Device details | Rename | F2 |

--- a/memdocs/intune/apps/company-portal-app.md
+++ b/memdocs/intune/apps/company-portal-app.md
@@ -228,8 +228,8 @@ The following keyboard shortcuts are available in the Windows Company Portal app
 |  | Remove | Ctrl+D or Delete |
 |  | Check access | Ctrl+M or F9 |
 | App details | Install | Ctrl+I |
-| App list tile | Install | Ctrl+I |
-| App list item | Install | Ctrl+I |
+| Apps list tile | Install | Ctrl+I |
+| Apps list item | Install | Ctrl+I |
 | Devices | Available | Ctrl+D |
 
 End users will also be able to see the available shortcuts in the Windows Company Portal app.

--- a/memdocs/intune/apps/company-portal-app.md
+++ b/memdocs/intune/apps/company-portal-app.md
@@ -230,7 +230,6 @@ The following keyboard shortcuts are available in the Windows Company Portal app
 | App details | Install | Ctrl+I |
 | Apps list tile | Install | Ctrl+I |
 | Apps list item | Install | Ctrl+I |
-| Devices | Available | Ctrl+D |
 
 End users will also be able to see the available shortcuts in the Windows Company Portal app.
 


### PR DESCRIPTION
While looking at the docs for the keyboard shortcuts for the Windows Company Portal, we noticed there were some missing. Specifically: the app tile and app list items have the shortcut Ctrl+I for install.