### PR TITLE
Update site-server-high-availability.md

### DIFF
--- a/memdocs/configmgr/core/servers/deploy/configure/site-server-high-availability.md
+++ b/memdocs/configmgr/core/servers/deploy/configure/site-server-high-availability.md
@@ -97,6 +97,8 @@ Microsoft Core Services Engineering and Operations used this feature to migrate 
 
   - Must have its computer account in the local Administrators group on the site server in active mode.<!--516036-->
 
+  - Must have local administrator rights on all site system servers.  
+
   - Must install using source files that match the version of the site server in active mode.  
 
   - Can't have a site system role from any site installed on it before you install the site server in passive mode role.  


### PR DESCRIPTION
Add prerequisite for site server in passive mode to have local administrator permissions on all site system servers. This is as per docs here:  https://docs.microsoft.com/en-us/mem/configmgr/core/plan-design/hierarchy/accounts#elevated-permissions, as well observations in live environments (post-installation task has a warning to check logs for missing permissions; as well if site server doesn't have permissions, after it is promoted to active, errors are reported, e.g. Site System Status Summarizer can't access remote site systems).