### PR TITLE
Please modify the Docs description details

### DIFF
--- a/memdocs/intune/protect/software-updates-ios.md
+++ b/memdocs/intune/protect/software-updates-ios.md
@@ -29,7 +29,7 @@ ms.collection: M365-identity-device-management
 
 # Add iOS/iPadOS software update policies in Intune
 
-Software update policies let you force supervised iOS/iPadOS devices to automatically install OS updates. [Supervised devices](../enrollment/device-enrollment-program-enroll-ios.md#what-is-supervised-mode) are devices that enrolled using either Apple Business Manager or Apple School Manager.
+Software update policies apply to supervised iOS/iPadOS devices to install OS updates. [Supervised devices](../enrollment/device-enrollment-program-enroll-ios.md#what-is-supervised-mode) are devices that enrolled using either Apple Business Manager or Apple School Manager.
 
 When configuring a policy to deploy updates, you can:
 


### PR DESCRIPTION
Docs and actual behavior does not match.
Please update docs or modify about the conditions which user can update iOS version automatically.

Docs describes "Let" but it might be too strong words. I think it seems have something conditions other than Supervised mode to update OS automatically.
Also, Apple said Now When user need to update OS version, User need to do manually step until they set AutoUpdate settings "ON".
Apple recognized and plan to improve these behavior in the future.(*User asked to Apple Support and got this answer from Apple)

Docs notes
"Software update policies let you force supervised iOS/iPadOS devices to automatically install OS updates"
https://docs.microsoft.com/en-us/mem/intune/protect/software-updates-ios

User confirmed behavior:
Policy didn't work as they expected. Pop Up message show and need to select bottom manually to update OS.