### PR TITLE
Please remove the description

### DIFF
--- a/memdocs/intune/protect/software-updates-ios.md
+++ b/memdocs/intune/protect/software-updates-ios.md
@@ -41,7 +41,7 @@ This feature applies to:
 - iOS 10.3 and later (supervised)
 - iPadOS 13.0 and later (supervised)
 
-By default, devices check in with Intune about every 8 hours. If an update is available through an update policy, the device downloads the update. The device then installs the update upon next check-in within your schedule configuration. Although the update process doesn't typically involve any user interaction, if the device has a passcode the user must enter it to start a software update. Profiles don't prevent users from updating the OS manually. Users can be prevented from updating the OS manually with a Device Configuration policy to restrict visibility of software updates.
+By default, devices check in with Intune about every 8 hours. If an update is available through an update policy, the device downloads the update. The device then installs the update upon next check-in within your schedule configuration. Profiles don't prevent users from updating the OS manually. Users can be prevented from updating the OS manually with a Device Configuration policy to restrict visibility of software updates.
 
 > [!NOTE]
 > If using [Autonomous Single App Mode (ASAM)](../configuration/device-restrictions-ios.md#autonomous-single-app-mode-asam), the impact of OS updates should be considered as the resulting behaviour may be undesirable.


### PR DESCRIPTION
"Although the update process doesn't typically involve any user interaction, if the device has a passcode the user must enter it to start a software update. "

The above description is not correct info.
As i told in  pull request before, Apple expressed to customer that iOS update need to user interaction. Also, this design will be change to not need to any user's interaction in the future. 
So, In current design, user need to interaction when iOS update will be done. I think that Our Docs need to modify the description.