### PR TITLE
Removed reference to IMEI corp identifier scenario

### DIFF
--- a/memdocs/intune/enrollment/enrollment-restrictions-set.md
+++ b/memdocs/intune/enrollment/enrollment-restrictions-set.md
@@ -150,7 +150,6 @@ The following methods qualify as being authorized as a Windows corporate enrollm
 - The enrolling user is using a [device enrollment manager account]( device-enrollment-manager-enroll.md).
 - The device enrolls through [Windows Autopilot](../../autopilot/enrollment-autopilot.md).
 - The device is registered with Windows Autopilot but isn't an MDM enrollment only option from Windows Settings.
-- The device's IMEI number is listed in **Device enrollment** > **[Corporate device identifiers](corporate-identifiers-add.md)**.
 - The device enrolls through a [bulk provisioning package](windows-bulk-enroll.md).
 - The device enrolls through GPO, or [automatic enrollment from Configuration Manager for co-management](/configmgr/comanage/quickstart-paths#bkmk_path1).
  


### PR DESCRIPTION
Docs reference lists Windows Corporate Identifier as unsupported for IMEI -
https://docs.microsoft.com/en-us/mem/intune/enrollment/corporate-identifiers-add#identify-corporate-owned-devices-with-imei-or-serial-number