### PR TITLE
Update task-sequence-steps.md

### DIFF
--- a/memdocs/configmgr/osd/understand/task-sequence-steps.md
+++ b/memdocs/configmgr/osd/understand/task-sequence-steps.md
@@ -1042,7 +1042,7 @@ Configuration Manager adds a numerical suffix to the variable name. For example,
 
 #### If a package download fails, continue downloading other packages in the list
 
-If the task sequence fails to download a package, it starts to download the next package in the list. This makes also the whole step to ignore download failures.
+If the task sequence fails to download a package, it starts to download the next package in the list. This behavior applies to all packages in the step. The task sequence ignores download failures for any referenced package.
 
 ### <a name="bkmk_note1"></a> Note 1: Use of boot images in the Download Package Content step
 

--- a/memdocs/configmgr/osd/understand/task-sequence-steps.md
+++ b/memdocs/configmgr/osd/understand/task-sequence-steps.md
@@ -1042,7 +1042,7 @@ Configuration Manager adds a numerical suffix to the variable name. For example,
 
 #### If a package download fails, continue downloading other packages in the list
 
-If the task sequence fails to download a package, it starts to download the next package in the list.  
+If the task sequence fails to download a package, it starts to download the next package in the list. This makes also the whole step to ignore download failures.
 
 ### <a name="bkmk_note1"></a> Note 1: Use of boot images in the Download Package Content step
 


### PR DESCRIPTION
This checkbox is equal to "continue on error" - there are almost no other reasons to fail "Download Content" step.