### PR TITLE
Add recently created accounts default setting

### DIFF
--- a/memdocs/intune/fundamentals/unlicensed-admins.md
+++ b/memdocs/intune/fundamentals/unlicensed-admins.md
@@ -31,7 +31,8 @@ ms.collection: M365-identity-device-management
 # Unlicensed admins
 
 You can give administrators access to Microsoft Endpoint Manager without them requiring an Intune license. This feature applies to any administrator, including Intune administrators, global administrators, Azure AD administrators, and so on. Other features or services, such as those in Azure Active Directory (AD) Premium, may require a license for the administrator.
-This "Unlicensed admins" option has been enabled by default on all accounts created after 2006 release.
+
+The Unlicensed admins option has been enabled by default on all accounts created after the 2006 release.
 
 ## Allow access
 

--- a/memdocs/intune/fundamentals/unlicensed-admins.md
+++ b/memdocs/intune/fundamentals/unlicensed-admins.md
@@ -31,6 +31,7 @@ ms.collection: M365-identity-device-management
 # Unlicensed admins
 
 You can give administrators access to Microsoft Endpoint Manager without them requiring an Intune license. This feature applies to any administrator, including Intune administrators, global administrators, Azure AD administrators, and so on. Other features or services, such as those in Azure Active Directory (AD) Premium, may require a license for the administrator.
+This "Unlicensed admins" option has been enabled by default on all accounts created after 2006 release.
 
 ## Allow access
 


### PR DESCRIPTION
Please add following notes in the docs.

This "Unlicensed admins" option has been enabled by default on all accounts created after 2006 release.

I confirmed that created account tenant in recently is this option has been enabled by default.
This option setting changed on 2006 release. Before 2006 release tenant users are able to be enabled in manually.