### PR TITLE
Update windows-10-feature-updates.md

### DIFF
--- a/memdocs/intune/protect/windows-10-feature-updates.md
+++ b/memdocs/intune/protect/windows-10-feature-updates.md
@@ -31,7 +31,7 @@ ms.collection: M365-identity-device-management
 
 *This feature is in public preview.*
 
-With *Windows 10 feature updates* in Intune, you can select the Windows [feature update](/windows/deployment/update/get-started-updates-channels-tools#types-of-updates) version that you want devices to remain at, like Windows 10 version 1803 or version 1809. Intune supports setting a feature level of 1803 or later.
+With *Windows 10 feature updates* in Intune, you can select the Windows [feature update](/windows/deployment/update/get-started-updates-channels-tools#types-of-updates) version that you want devices to remain at, like Windows 10 version 1909 or version 2004. Intune supports setting a feature level of 1909 or later.
 
 Windows 10 feature updates policies work with your *Windows 10 update ring* policies to prevent a device from receiving a Windows feature version that’s later than the value specified in the feature updates policy.
 


### PR DESCRIPTION
I'm not certain this is absolutely accurate.  The "Feature updates" policy in Intune doesn't allow anything prior to 1909 today (unless I'm looking at something wrong).  I'm assuming that we're going to restrict "pinning" to only supported versions of the OS.  Might make sense to take the version callout out of this doc entirely and explain it as "...that you want devices to remain at.  This only includes currently supported versions of Windows 10."  Maybe even make it a purple note so that it's clearer.