### PR TITLE
Updated App protection Global policy section

### DIFF
--- a/memdocs/intune/apps/app-protection-policy.md
+++ b/memdocs/intune/apps/app-protection-policy.md
@@ -209,7 +209,7 @@ By default, there can only be one **Global** policy per tenant. However, you can
 While the **Global** policy applies to all users in your tenant, any standard Intune app protection policy will override these settings.
 
 > [!NOTE]
-> The policy settings in the OneDrive Admin Center are no longer being updated. Microsoft Enpoint Manager may be used instead. For more information, see [Control access to features in the OneDrive and SharePoint mobile apps](/onedrive/control-access-to-mobile-app-features).
+> The policy settings in the OneDrive Admin Center are no longer being updated. Microsoft Enpoint Manager may be used instead. For more information, see [Control access to features in the OneDrive and SharePoint mobile apps](/onedrive/control-access-to-mobile-app-features.md).
 
 ## App protection features
 

--- a/memdocs/intune/apps/app-protection-policy.md
+++ b/memdocs/intune/apps/app-protection-policy.md
@@ -208,6 +208,9 @@ By default, there can only be one **Global** policy per tenant. However, you can
 
 While the **Global** policy applies to all users in your tenant, any standard Intune app protection policy will override these settings.
 
+> [!NOTE]
+> [The policy settings in the OneDrive Admin Center are no longer being updated.](https://docs.microsoft.com/en-us/onedrive/control-access-to-mobile-app-features) Microsoft Enpoint Manager may be used instead.
+
 ## App protection features
 
 ### Multi-identity

--- a/memdocs/intune/apps/app-protection-policy.md
+++ b/memdocs/intune/apps/app-protection-policy.md
@@ -209,7 +209,7 @@ By default, there can only be one **Global** policy per tenant. However, you can
 While the **Global** policy applies to all users in your tenant, any standard Intune app protection policy will override these settings.
 
 > [!NOTE]
-> The policy settings in the OneDrive Admin Center are no longer being updated. Microsoft Enpoint Manager may be used instead. For more information, see [Control access to features in the OneDrive and SharePoint mobile apps](/onedrive/control-access-to-mobile-app-features.md).
+> The policy settings in the OneDrive Admin Center are no longer being updated. Microsoft Enpoint Manager may be used instead. For more information, see [Control access to features in the OneDrive and SharePoint mobile apps](/onedrive/control-access-to-mobile-app-features).
 
 ## App protection features
 

--- a/memdocs/intune/apps/app-protection-policy.md
+++ b/memdocs/intune/apps/app-protection-policy.md
@@ -8,7 +8,7 @@ keywords:
 author: Erikre
 ms.author: erikre
 manager: dougeby
-ms.date: 03/14/2021
+ms.date: 07/13/2021
 ms.topic: overview
 ms.service: microsoft-intune
 ms.subservice: apps
@@ -209,7 +209,7 @@ By default, there can only be one **Global** policy per tenant. However, you can
 While the **Global** policy applies to all users in your tenant, any standard Intune app protection policy will override these settings.
 
 > [!NOTE]
-> [The policy settings in the OneDrive Admin Center are no longer being updated.](https://docs.microsoft.com/en-us/onedrive/control-access-to-mobile-app-features) Microsoft Enpoint Manager may be used instead.
+> The policy settings in the OneDrive Admin Center are no longer being updated. Microsoft Enpoint Manager may be used instead. For more information, see [Control access to features in the OneDrive and SharePoint mobile apps](/onedrive/control-access-to-mobile-app-features.md).
 
 ## App protection features
 


### PR DESCRIPTION
I added a note with a link to other documentation stating that the OneDrive Admin Center is no longer being updated and that Microsoft Endpoint Manager can be used.

Addresses issue #1553 