### PR TITLE
Update device-enrollment-program-enroll-ios.md

### DIFF
--- a/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
+++ b/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
@@ -276,7 +276,7 @@ Now that you've installed your token, you can create an enrollment profile for A
     > [!NOTE]
     > A device wipe will be required if an iOS/iPadOS enrollment profile with Shared iPad enabled is sent to an unsupported device. Unsupported devices include any iPhone models,  and iPads running iPadOS/iOS 13.3 and earlier. Supported devices include iPads running iPadOS 13.3 and later.
 
-    If you configured your devices as Apple Shared iPad for Business devices, you need to set **Maximum cached users**. This setting is supported by iPadOS version 14.3.x and earlier. Set this value to the number of users that you expect to use the shared iPad. You can cache up to 24 users on a 32-GB or 64-GB device. If you choose a low number, it might take a while for your users' data to appear on their devices after they sign in. If you choose a high number, your users might not have enough disk space.  
+    If you configured your devices as Apple Shared iPad for Business devices, you need to set **Maximum cached users**. Set this value to the number of users that you expect to use the shared iPad. You can cache up to 24 users on a 32-GB or 64-GB device. If you choose a low number, it might take a while for your users' data to appear on their devices after they sign in. If you choose a high number, your users might not have enough disk space.  
 
     > [!NOTE]
     > If you want to set up Apple Shared iPad for Business, configure these settings:


### PR DESCRIPTION
deleting the note about iPadOS 14.3.x and earlier because this was fixed with 2107, which has rolled out.