### PR TITLE
You cannot use exported .csv file to import devices to Autopilot

### DIFF
--- a/memdocs/analytics/work-from-anywhere.md
+++ b/memdocs/analytics/work-from-anywhere.md
@@ -72,7 +72,7 @@ Cloud provisioning provides a simpler initial provisioning experience for Window
 
 > [!NOTE] 
 > - Currently, only devices that didn't receive a score of 100 are shown in the metric's device list. <!--10155338-->
-> - You can export a device list as a `.csv` file from **Cloud provisioning** and use it to [Manually register devices with Windows Autopilot](../autopilot/add-devices.md#add-devices).
+> - You can export a device list as a `.csv` file from **Cloud provisioning** 
 
 :::image type="content" source="media/8668496-cloud-provisioning.png" alt-text="Screenshot of the cloud provisioning tab showing the device list":::
 


### PR DESCRIPTION
Under Cloud Provisioning I removed the following statement: You can export a device list as a `.csv` file from **Cloud provisioning** and use it to [Manually register devices with Windows Autopilot](../autopilot/add-devices.md#add-devices).

From: https://docs.microsoft.com/en-us/mem/autopilot/add-devices#add-devices, the CSV must comply with the following requirements: 
"The header and line format is shown below:

Device Serial Number,Windows Product ID,Hardware Hash,Group Tag,Assigned User
<serialNumber>,<ProductID>,<hardwareHash>,<optionalGroupTag>,<optionalAssignedUser>"
and
"The CSV file being imported into the Intune portal must be formatted as described above. Extra columns are not supported."

The exported CSV from Endpoint Analytics doesn't have the same column headers and contains extra columns. I think that hardwareHash is also required, which is missing from the exported CSV.