### PR TITLE
Update windows-autopilot-hybrid.md

### DIFF
--- a/memdocs/autopilot/windows-autopilot-hybrid.md
+++ b/memdocs/autopilot/windows-autopilot-hybrid.md
@@ -249,7 +249,7 @@ It takes about 15 minutes for the device profile status to change from *Not assi
     - If you leave this blank, the computer object will be created in the Active Directory default container (CN=Computers if you never [changed it](https://support.microsoft.com/help/324949/redirecting-the-users-and-computers-containers-in-active-directory-dom)).
  
     Here are some valid examples:
-      - OU=Level 1,OU=Level2,DC=contoso,DC=com
+      - OU=Sub OU,OU=TopLevel OU,DC=contoso,DC=com
       - OU=Mine,DC=contoso,DC=com
  
     Here are some examples that aren't valid:


### PR DESCRIPTION
OU=Level 1,OU=Level2,DC=contoso,DC=com is confusing and is open to misinterpretation. When looking in AD it could be interpreted as 

```
Level 1 >
   Level2  
```

when in actuality the structure in AD for this distinguished name is:

```
Level2 >
    Level 1
```