### PR TITLE
Update encrypt-devices.md

### DIFF
--- a/memdocs/intune/protect/encrypt-devices.md
+++ b/memdocs/intune/protect/encrypt-devices.md
@@ -162,6 +162,9 @@ Intune provides access to the Azure AD blade for BitLocker so you can view BitLo
 
    When keys aren't in Azure AD, Intune will display *No BitLocker key found for this device*.
 
+ > [!NOTE]
+ > Currently Azure AD supports a maximum of 200 Bitlocker Recovery Keys per Device. Should you rach this limit, silent encryption will fail owing to the failing backup of recovery keys before starting encryption on the device.
+
 Information for BitLocker is obtained using the [BitLocker configuration service provider](/windows/client-management/mdm/bitlocker-csp) (CSP). BitLocker CSP is supported on Windows 10 version 1703 and later, and for Windows 10 Pro version 1809 and later.
 
 IT admins need to have a specific permission within Azure Active Directory to be able to see device BitLocker recovery keys: `microsoft.directory/bitlockerKeys/key/read`. There are some roles within Azure AD that come with this permission, including Cloud Device Administrator, Helpdesk Administrator, etc. For more information on which Azure AD roles have which permissions, see [Azure AD role descriptions](/azure/active-directory/roles/permissions-reference). 

--- a/memdocs/intune/protect/encrypt-devices.md
+++ b/memdocs/intune/protect/encrypt-devices.md
@@ -163,7 +163,7 @@ Intune provides access to the Azure AD blade for BitLocker so you can view BitLo
    When keys aren't in Azure AD, Intune will display *No BitLocker key found for this device*.
 
 > [!NOTE]
-> Currently Azure AD supports a maximum of 200 Bitlocker Recovery Keys per Device. Should you reach this limit, silent encryption will fail due to the failing backup of recovery keys before starting encryption on the device.
+> Currently, Azure AD supports a maximum of 200 BitLocker recovery keys per device. If you reach this limit, silent encryption will fail due to the failing backup of recovery keys before starting encryption on the device.
 
 Information for BitLocker is obtained using the [BitLocker configuration service provider](/windows/client-management/mdm/bitlocker-csp) (CSP). BitLocker CSP is supported on Windows 10 version 1703 and later, and for Windows 10 Pro version 1809 and later.
 

--- a/memdocs/intune/protect/encrypt-devices.md
+++ b/memdocs/intune/protect/encrypt-devices.md
@@ -162,8 +162,8 @@ Intune provides access to the Azure AD blade for BitLocker so you can view BitLo
 
    When keys aren't in Azure AD, Intune will display *No BitLocker key found for this device*.
 
- > [!NOTE]
- > Currently Azure AD supports a maximum of 200 Bitlocker Recovery Keys per Device. Should you rach this limit, silent encryption will fail owing to the failing backup of recovery keys before starting encryption on the device.
+> [!NOTE]
+> Currently Azure AD supports a maximum of 200 Bitlocker Recovery Keys per Device. Should you reach this limit, silent encryption will fail due to the failing backup of recovery keys before starting encryption on the device.
 
 Information for BitLocker is obtained using the [BitLocker configuration service provider](/windows/client-management/mdm/bitlocker-csp) (CSP). BitLocker CSP is supported on Windows 10 version 1703 and later, and for Windows 10 Pro version 1809 and later.
 


### PR DESCRIPTION
Adding pertinent information on the upper limit i.e. a maximum of 200 Bitlocker Keys which can be backed up to Azure AD for a Device. A lot of customers are running into this specific limit and hence unable to start encryption. We provide a workaround however they also ask for a Public facing documentation.