### PR TITLE
Update missing word "Enroll devices"

### DIFF
--- a/memdocs/autopilot/registration-overview.md
+++ b/memdocs/autopilot/registration-overview.md
@@ -74,7 +74,7 @@ For more information about device IDs, see the following topics:
 
 ## Windows Autopilot devices
 
-Devices that have been registered with the Windows Autopilot service are displayed in the [admin center](https://go.microsoft.com/fwlink/?linkid=2109431) under **Devices | Windows enrollment** > **Windows Autopilot Deployment Program** > **Devices**:
+Devices that have been registered with the Windows Autopilot service are displayed in the [admin center](https://go.microsoft.com/fwlink/?linkid=2109431) under **Devices > **Enroll devices** | Windows enrollment** > **Windows Autopilot Deployment Program** > **Devices**:
 
 ![Autopilot devices](images/ap-devices.png)
 


### PR DESCRIPTION
Hi, Please update on below link missing word "Enroll devices" for Windows Autopilot devices section

Link > https://docs.microsoft.com/en-us/mem/autopilot/registration-overview#windows-autopilot-devices