### PR TITLE
"Applies to Windows 11" section should be update

### DIFF
--- a/memdocs/autopilot/registration-overview.md
+++ b/memdocs/autopilot/registration-overview.md
@@ -25,6 +25,7 @@ ms.collection:
 **Applies to**
 
 - Windows 10
+- Windows 11
 - Windows Holographic, version 2004
 
 Before deploying a device using Windows Autopilot, the device must be registered with the Windows Autopilot deployment service. 


### PR DESCRIPTION
Hi, 
If What's new Autopilot page is updated with "Applies to Windows 11" then it should be also updated for below link as well is this correct ?

Link > https://docs.microsoft.com/en-us/mem/autopilot/registration-overview