### PR TITLE
Add missing Switch/parameter for ccmsetup.exe

### DIFF
--- a/memdocs/configmgr/core/clients/deploy/about-client-installation-properties.md
+++ b/memdocs/configmgr/core/clients/deploy/about-client-installation-properties.md
@@ -2,7 +2,7 @@
 title: Client installation parameters and properties
 titleSuffix: Configuration Manager
 description: Learn about the ccmsetup command-line parameters and properties for installing the Configuration Manager client.
-ms.date: 09/09/2021
+ms.date: 09/22/2021
 ms.prod: configuration-manager
 ms.technology: configmgr-client
 ms.topic: reference
@@ -291,9 +291,9 @@ If a device uses Azure Active Directory (Azure AD) for client authentication and
 >
 > Also specify this parameter when you install a client for internet-only communication. Use `CCMALWAYSINF=1` together with the properties for the internet-based management point (**CCMHOSTNAME**) and the site code (**SMSSITECODE**). For more information about internet-based client management, see [Considerations for client communications from the internet or an untrusted forest](../../plan-design/hierarchy/communications-between-endpoints.md#BKMK_clientspan).
 
-## /IgnoreSkipUpgrade
+### /IgnoreSkipUpgrade
 
-Specify this parameter to manually upgrade an excluded client
+Specify this parameter to manually upgrade an excluded client. For more information, see [How to exclude clients from upgrade](../manage/upgrade/exclude-clients-windows.md).<!-- MEMDocs#1996 -->
 
 ## <a name="ccmsetupReturnCodes"></a> CCMSetup.exe return codes
 

--- a/memdocs/configmgr/core/clients/deploy/about-client-installation-properties.md
+++ b/memdocs/configmgr/core/clients/deploy/about-client-installation-properties.md
@@ -291,6 +291,10 @@ If a device uses Azure Active Directory (Azure AD) for client authentication and
 >
 > Also specify this parameter when you install a client for internet-only communication. Use `CCMALWAYSINF=1` together with the properties for the internet-based management point (**CCMHOSTNAME**) and the site code (**SMSSITECODE**). For more information about internet-based client management, see [Considerations for client communications from the internet or an untrusted forest](../../plan-design/hierarchy/communications-between-endpoints.md#BKMK_clientspan).
 
+## /IgnoreSkipUpgrade
+
+Specify this parameter to manually upgrade an excluded client
+
 ## <a name="ccmsetupReturnCodes"></a> CCMSetup.exe return codes
 
 The CCMSetup.exe command provides the following return codes. To troubleshoot, review `%WinDir%\ccmsetup\Logs\ccmsetup.log` on the client for context and additional detail about return codes.


### PR DESCRIPTION
The parameter is missing on the "Client Installation Properties" page, and can only be found on the "How to upgrade an excluded client" part of the "How to exclude clients from upgrade in Configuration Manager" page.

Probably could use a better description than what i put in there.