### PR TITLE
Adding information for ValuesToScrubFromLogging

### DIFF
--- a/memdocs/intune/developer/app-sdk-ios.md
+++ b/memdocs/intune/developer/app-sdk-ios.md
@@ -263,6 +263,7 @@ WebViewHandledURLSchemes | Array of Strings | Specifies the URL schemes that you
 DocumentBrowserFileCachePath | String | If your app uses the [`UIDocumentBrowserViewController`](https://developer.apple.com/documentation/uikit/uidocumentbrowserviewcontroller?language=objc) to browse through files in various file providers, you can set this path relative to the home directory in the application sandbox so the Intune SDK can drop decrypted managed files into that folder. | Optional. Defaults to the `/Documents/` directory. |
 VerboseLoggingEnabled | Boolean | If set to YES, Intune will log in verbose mode. | Optional. Defaults to NO |
 FinishLaunchingAtStartup | Boolean | If the app is using `[BGTaskScheduler registerForTaskWithIdentifier:]` then this setting should be set to YES. | Optional. Defaults to NO |
+ValuesToScrubFromLogging | Array of Strings | Specifies Application Configuration values that should be scrubbed from the logs. Alternatively, the valuesToScrubFromLogging property on the IntuneMAMSettings class can be given an array of strings for the same behavior. | Optional. |
 
 ## Receive app protection policy
 


### PR DESCRIPTION
App developers can now add a list of app config values that they'd like to have scrubbed from the logs. This documentation update to the "Configure settings for the Intune App SDK" section at the bottom of the list will let users know how to do this.