### PR TITLE
Update teamviewer-support.md

### DIFF
--- a/memdocs/intune/remote-actions/teamviewer-support.md
+++ b/memdocs/intune/remote-actions/teamviewer-support.md
@@ -58,7 +58,7 @@ This feature applies to:
 
   > [!NOTE]
   >
-  >   - Organization-owned devices are not supported. Team viewer works with the Company portal app. It doesn't work with the Intune app.
+  >   - Android Enteprise corporate-owned devices are not supported. Team viewer works with the Company portal app. It doesn't work with the Intune app.
   >  - TeamViewer may not support Windows Holographic (HoloLens), Windows Team (Surface Hub), or Windows 10 S. For supportability, see [TeamViewer](https://www.teamviewer.com) (opens TeamViewer's web site) for any updates.
 
 - A [TeamViewer](https://www.teamviewer.com) (opens TeamViewer's web site) account with the sign-in credentials. Only some TeamViewer licenses may support integration with Intune. For specific TeamViewer needs, see [TeamViewer Integration Partner: Microsoft Intune](https://www.teamviewer.com/integrations/microsoft-intune/).


### PR DESCRIPTION
This seems that windows 10 and ios treated as corporate-owned device are not supported.

But I confired it is possible to remote assist to corporate-owned WIndows 10 device.

I think this is writen about only Android Enteprise corporate-owned devices