### PR TITLE
Updated new wording on Cloud attach wizard

### DIFF
--- a/memdocs/configmgr/tenant-attach/device-sync-actions.md
+++ b/memdocs/configmgr/tenant-attach/device-sync-actions.md
@@ -95,7 +95,7 @@ When co-management isn't enabled, use the instructions below to enable device up
 1. On the onboarding page, select **AzurePublicCloud** for your environment. Azure Government Cloud and Azure China 21Vianet aren't supported.
    - Starting in version 2107, US Government customers can select **AzureUSGovernmentCloud**.<!-- 8353823 -->
 1. Select **Sign In**. Use your *Global Administrator* account to sign in.
-1. Ensure the **Upload to Microsoft Endpoint Manager admin center** option is selected on the onboarding** page.
+1. Ensure the **Enable Microsoft Endpoint Manager admin center** option is selected on the **Cloud attach** page. For version 2103 and earlier, select the **Upload to Microsoft Endpoint Manager admin center** option on the **Tenant onboarding** page.
    - Make sure the option **Enable automatic client enrollment for co-management** isn't checked if you don't want to enable co-management now. If you do want to enable co-management, select the option.
    - If you enable co-management along with device upload, you'll be given additional pages in the wizard to complete. For more information, see [Enable co-management](../comanage/how-to-enable.md).
 


### PR DESCRIPTION
The option "Upload to Microsoft Endpoint Manager admin center" is now called "Enable Microsoft Endpoint Manager admin center". Updated wording to reflect that.