### PR TITLE
Update "Assign a user to a specific Autopilot device" section

### DIFF
--- a/memdocs/autopilot/enrollment-autopilot.md
+++ b/memdocs/autopilot/enrollment-autopilot.md
@@ -78,6 +78,10 @@ For information about formatting and using a CSV file to manually add Windows Au
 
 ## Assign a user to a specific Autopilot device
 
+> [!NOTE]
+> This functionality has been removed as of September 30, 2021.
+> While the option to assign user to a device in Autopilot is still available in the GUI portal and PowerShell, it will be ignored by the device during provisioning.
+
 You can assign a licensed Intune user to a specific Autopilot device. This assignment:
 - Pre-fills a user from Azure Active Directory in the [company-branded](/azure/active-directory/fundamentals/customize-branding) sign-in page during Windows setup.
 - Lets you set a custom greeting name.


### PR DESCRIPTION
As confirmed by CSS, the functionality has been removed as of September 30, 2021.
I've noticed the setting being ignored as I was in the middle of customer project and had just demoed the custom greeting page to them, only to have it gone next day.

Suggest placing the NOTE section in the article until the functionality is removed from the portal/PoSh module - for consistency.
When it's finally gone, remove the whole section altogether.