### PR TITLE
Update create-deploy-exploit-guard-policy.md

### DIFF
--- a/memdocs/configmgr/protect/deploy-use/create-deploy-exploit-guard-policy.md
+++ b/memdocs/configmgr/protect/deploy-use/create-deploy-exploit-guard-policy.md
@@ -30,7 +30,7 @@ Compliance data for Exploit Guard policy deployment is available from within the
 
 ## Prerequisites
 
-Managed devices must run Windows 10 1709 or later; the minimum Windows Server build is version is 1809 or later.satisfy the following requirements depending on the components and rules configured:
+Managed devices must run Windows 10 1709 or later; the minimum Windows Server build is version 1809 or later. The following requirements must also be satisfied, depending on the components and rules configured:
 
 |Exploit Guard component |Additional prerequisites|
 |------------------------|------------------------|


### PR DESCRIPTION
Updated requirements to Managed devices must run Windows 10 1709 or later; the minimum Windows Server build is version is 1809 or later.satisfy the following requirements depending on the components and rules configured: