### PR TITLE
Modify the validity period of the certificate template

### DIFF
--- a/memdocs/intune/protect/certificates-scep-configure.md
+++ b/memdocs/intune/protect/certificates-scep-configure.md
@@ -280,6 +280,7 @@ Plan to use a validity period of five days or greater. When the validity period 
 
 > [!IMPORTANT]
 > For iOS/iPadOS and macOS, always use a value set in the template.
+> **Warning:** This is a global setting and will configure your CA to stop enforcing certificate validity periods set in all templates assigned.
 
 #### To configure a value that can be set from within the Intune console
 


### PR DESCRIPTION
I think a warning is required when calling out this configuration option. As per the following article:-

https://techcommunity.microsoft.com/t5/core-infrastructure-and-security/ndes-security-best-practices/bc-p/2856089#M4020

"This is a global setting and will configure your CA to stop enforcing certificate validity periods set in all templates assigned".