### PR TITLE
Change Windows 10 8C+ for 19H2 and 20H1 to more understandable

### DIFF
--- a/memdocs/autopilot/windows-autopilot-whats-new.md
+++ b/memdocs/autopilot/windows-autopilot-whats-new.md
@@ -28,7 +28,7 @@ ms.topic: article
 
 ## Autopilot agility rolling out
 
-Autopilot agility is a new feature that allows updates and bug fixes to the OOBE experience. These updates occur before device enrollment, after the AADJ login page and may result in an additional reboot and authentication prompt to the user. This feature is rolling out to Windows 10 8C+ for 19H2 and 20H1 and is not yet available for Windows 11.
+Autopilot agility is a new feature that allows updates and bug fixes to the OOBE experience. These updates occur before device enrollment, after the AADJ login page and may result in an additional reboot and authentication prompt to the user. This feature is rolling out to Windows 10 1909 and 2004/20H2 with August cumulative update and is not yet available for Windows 11.
 
 ## One-time self-deployment and pre-provisioning
 


### PR DESCRIPTION
"Windows 10 8C+ for 19H2 and 20H1" doesn't make any sense to anyone outside Microsoft!

I'm assuming that 8C refers to August cumulative update?
Windows 10 19H2 must mean Windows 10 1909?
And finally Windows 20H1 is better known as Windows 2004. Also it should be mentioned that the feature is supported in Windows 10 20H2.