### PR TITLE
Add note about multiple users

### DIFF
--- a/memdocs/configmgr/osd/deploy-use/use-software-center-to-deploy-windows-over-the-network.md
+++ b/memdocs/configmgr/osd/deploy-use/use-software-center-to-deploy-windows-over-the-network.md
@@ -43,6 +43,8 @@ Also configure whether the deployment is required or available:
 - Available deployment: The task sequence is available in Software Center, and a user can install it on demand.
 
 After you create the deployment, clients in the target collection will show the task sequence in Software Center.
+    > [!NOTE]
+    > If multiple users are signed into the device, task sequence deployments may not appear in Software Center until additional users are logged off.
 
 ## Next steps
 

--- a/memdocs/configmgr/osd/deploy-use/use-software-center-to-deploy-windows-over-the-network.md
+++ b/memdocs/configmgr/osd/deploy-use/use-software-center-to-deploy-windows-over-the-network.md
@@ -43,8 +43,9 @@ Also configure whether the deployment is required or available:
 - Available deployment: The task sequence is available in Software Center, and a user can install it on demand.
 
 After you create the deployment, clients in the target collection will show the task sequence in Software Center.
-    > [!NOTE]
-    > If multiple users are signed into the device, task sequence deployments may not appear in Software Center until additional users are logged off.
+    
+> [!NOTE]
+> If multiple users are signed in on the device, task sequence deployments might not appear in Software Center until other users are signed out.
 
 ## Next steps
 


### PR DESCRIPTION
Added note her about multiple logged on users and task sequences not showing in Software Center.

Per Aaron's suggestion on Twitter to add this in a more visible place.  There are a few other docs where it may make sense, but many link to this one.