### PR TITLE
Clarify contradicting statements

### DIFF
--- a/memdocs/intune/user-help/what-info-can-your-company-see-when-you-enroll-your-device-in-intune.md
+++ b/memdocs/intune/user-help/what-info-can-your-company-see-when-you-enroll-your-device-in-intune.md
@@ -43,7 +43,7 @@ Your organization cannot see your personal information when you enroll a device 
 - Passwords
 - Pictures, including what's in the photos app or camera roll
 - Files
-- Additionally, for corporate-owned devices with a work profile:  
+- Additionally, for corporate-owned Android devices with a work profile:
   - Apps and data in your personal profile
   - Phone number 
 
@@ -52,7 +52,7 @@ Your organization cannot see your personal information when you enroll a device 
 - Device model, like Google Pixel
 - Device manufacturer, like Microsoft
 - Operating system and version, like iOS 12.0.1
-- App inventory and app names, like Microsoft Word. On personal devices, your organization can only see your managed app inventory. For corporate-owned fully managed and dedicated devices, your organization can see all of your app inventory. For corporate-owned devices with a work profile, your organization can only see the app inventory in your work profile.
+- App inventory and app names, like Microsoft Word. On personal devices, your organization can only see your managed app inventory. For corporate devices, your organization can see all of your app inventory. For corporate-owned Android devices with a work profile, your organization can only see the app inventory in your work profile.
 - Device owner
 - Device name
 - Device serial number


### PR DESCRIPTION
This article refers to enrollments for all platform, but the wording of "fully managed and dedicated devices" is mostly used in Android Enterprise scenarios only. This leads to a lot of confusion with the note directly under it that states all Android Enterprise do not have access to app inventory.

While at it, clarified "corporate-owned devices with work profiles" refers to Android devices, since this is not an Android-specific page.