### PR TITLE
Update advanced-threat-protection-configure.md

### DIFF
--- a/memdocs/intune/protect/advanced-threat-protection-configure.md
+++ b/memdocs/intune/protect/advanced-threat-protection-configure.md
@@ -57,7 +57,7 @@ You only need to enable Microsoft Defender for Endpoint a single time per tenant
    :::image type="content" source="./media/advanced-threat-protection-configure/atp-device-compliance-open-microsoft-defender.png" alt-text="Screen shot that shows the patch to open the Microsoft Defender Security Center.":::
 
 3. In **Microsoft Defender Security Center**:
-   1. Select **Settings** > **Advanced features**.
+   1. Select **Settings** > **Endpoints** >**Advanced features**.
    2. For **Microsoft Intune connection**, choose **On**:
 
       :::image type="content" source="./media/advanced-threat-protection-configure/atp-security-center-intune-toggle.png" alt-text="Screen shot of the Microsoft Intune connection setting.":::


### PR DESCRIPTION
When clicking on the "open the Microsoft Defender Security center" link in the Endpoint Manager Portal, the URL is securitycenter.windows.com

However it looks that URL now redirects to the M365 Defender console instead. As such, the UI has changed and the path to navigate to the "Microsoft Intune connection" setting is slightly different than what is described in this article. This caused some confusion for me and my customer, so I am proposing a change with the correct path.