### PR TITLE
Update packages-and-programs: drive letter

### DIFF
--- a/memdocs/configmgr/apps/deploy-use/packages-and-programs.md
+++ b/memdocs/configmgr/apps/deploy-use/packages-and-programs.md
@@ -119,9 +119,9 @@ Packages can use some new features of Configuration Manager, including distribut
 
         - **Runs with UNC name**: Specify that the program runs with a Universal Naming Convention (UNC) name. This setting is the default.  
 
-        - **Requires drive letter**: Specify that the program requires a drive letter to fully qualify its location. For this setting, Configuration Manager can use any available drive letter on the client.  
+        - **Requires drive letter**: Specify that the program requires a drive letter to fully qualify its location. For this setting, Configuration Manager can use any available drive letter on the client.  This setting requires the deployment to use the Deployment option **Run program from distribution point** and the package's Data Access option enabled to **Copy the content in this package to a package share on distribution points**.
 
-        - **Requires specific drive letter**: Specify that the program requires a specific drive letter that you specify to fully qualify its location. For example, **Z:**. If the client is already using the specified drive letter, the program doesn't run.  
+        - **Requires specific drive letter**: Specify that the program requires a specific drive letter that you specify to fully qualify its location. For example, **Z:**. If the client is already using the specified drive letter, the program doesn't run.  This setting requires the deployment to use the Deployment option **Run program from distribution point** and the package's Data Access option enabled to **Copy the content in this package to a package share on distribution points**.
 
     - **Reconnect to distribution point at log on**: Indicate whether the client reconnects to the distribution point when the user signs in. By default, the wizard doesn't enable this option.
 


### PR DESCRIPTION
Add detail to a standard program for using a drive letter which requires mapping a drive to a distribution point