### PR TITLE
Update to smsdbrole_AITool

### DIFF
--- a/memdocs/configmgr/core/plan-design/hierarchy/accounts.md
+++ b/memdocs/configmgr/core/plan-design/hierarchy/accounts.md
@@ -650,7 +650,7 @@ Configuration Manager automatically creates and maintains the following role obj
 
 ### smsdbrole_AITool
 
-Configuration Manager grants this permission to users accounts based on role-based access to import volume license information for Asset Intelligence. This account could be added by a Full Administrator or Asset Manager role.
+Configuration Manager grants this permission to administrative user accounts based on role-based access to import volume license information for Asset Intelligence. This account could be added by a Full Administrator, Operations Administrator or Asset Manager role, or any role with 'Manage Asset Intelligence' permission.
 
 ### smsdbrole_AIUS
 


### PR DESCRIPTION
This is important because this is the only permission that triggers creation of SQL Logins for administrative users, which can raise questions by admins.