### PR TITLE
Update internet-endpoints.md

### DIFF
--- a/memdocs/configmgr/core/plan-design/network/internet-endpoints.md
+++ b/memdocs/configmgr/core/plan-design/network/internet-endpoints.md
@@ -50,6 +50,8 @@ For more information, see [Updates and servicing](../../servers/manage/updates.m
 
 - `download.windowsupdate.com`  
 
+- `download.visualstudio.microsoft.com`  
+
 - `sccmconnected-a01.cloudapp.net`  
 
 - `configmgrbits.azureedge.net`


### PR DESCRIPTION
Starting from 2111 we download .NET 4.6.2 via the link: 
Downloading https://go.microsoft.com/fwlink/?LinkID=2171070 as NDP462-KB3151800-x86-x64-AllOS-ENU.exe

This shortcut link redirects to: https://download.visualstudio.microsoft.com/download/pr/8e396c75-4d0d-41d3-aea8-848babc2736a/80b431456d8866ebe053eb8b81a168b3/ndp462-kb3151800-x86-x64-allos-enu.exe