### PR TITLE
Update public-preview.md

### DIFF
--- a/memdocs/intune/fundamentals/public-preview.md
+++ b/memdocs/intune/fundamentals/public-preview.md
@@ -43,7 +43,7 @@ When working with features in public preview, these features:
 - May have restricted or limited functionality. For example, the feature may only apply to one platform.
 - Typically go through feature changes before they're generally available (GA).
 - Are fully supported by Microsoft.
-- May only be available in selected geographic regions or cloud environments. For example, the feature may not exist in the government cloud.
+- May only be available in selected geographic regions or cloud environments. For example, the feature may not exist in the [Azure Government](https://docs.microsoft.com/azure/azure-government/documentation-government-welcome) cloud.
 - Individual features in preview may have more usage and support restrictions. If so, this information is typically noted in the feature documentation.
 
 ## Next steps

--- a/memdocs/intune/fundamentals/public-preview.md
+++ b/memdocs/intune/fundamentals/public-preview.md
@@ -7,7 +7,7 @@ keywords:
 author: MandiOhlinger
 ms.author: mandia
 manager: dougeby
-ms.date: 04/05/2021
+ms.date: 01/13/2022
 ms.topic: conceptual
 ms.service: microsoft-intune
 ms.subservice: fundamentals
@@ -43,7 +43,7 @@ When working with features in public preview, these features:
 - May have restricted or limited functionality. For example, the feature may only apply to one platform.
 - Typically go through feature changes before they're generally available (GA).
 - Are fully supported by Microsoft.
-- May only be available in selected geographic regions or cloud environments. For example, the feature may not exist in the [Azure Government](https://docs.microsoft.com/azure/azure-government/documentation-government-welcome) cloud.
+- May only be available in selected geographic regions or cloud environments. For example, the feature may not exist in the [Azure Government](/azure/azure-government/documentation-government-welcome) cloud.
 - Individual features in preview may have more usage and support restrictions. If so, this information is typically noted in the feature documentation.
 
 ## Next steps


### PR DESCRIPTION
Clarified what "the government cloud" is, capitalized it correctly and provided a hyperlink to the Overview page.