### PR TITLE
Update device-enrollment-manager-enroll.md

### DIFF
--- a/memdocs/intune/enrollment/device-enrollment-manager-enroll.md
+++ b/memdocs/intune/enrollment/device-enrollment-manager-enroll.md
@@ -45,7 +45,6 @@ DEM user accounts and devices that are enrolled with a DEM user account have the
 - DEM user accounts cannot use Apple Volume Purchase Program (VPP) apps with Apple VPP user licenses because of per-user Apple ID requirements for app management.
 - DEM accounts cannot be used when enrolling devices via Apple's Automated Device Enrollment (ADE).
 - Devices can install VPP apps if they have Apple VPP device licenses.
-- On Windows 10 1709 and older, conditional access isn't available for Windows devices enrolled using bulk enrollment.
 - Every device enrolled with DEM accounts needs to be properly licensed to be managed by Intune. The license could be an Intune user license or an Intune device license.
 - If you're [enrolling Android Enterprise personally-owned devices with work profile](android-work-profile-enroll.md) using a DEM account, there is a limit of 10 devices that can be enrolled per account.
 - [Enrolling Android Enterprise fully managed devices](android-fully-managed-enroll.md) with DEM accounts isn't supported.


### PR DESCRIPTION
Deleted outdated reference to remove clutter. Do we really need to point out limitations in Windows 1709 which was EoS several years ago? We're not supporting Windows 10 1709 management in Intune anyway so it makes no sense in explicitly calling out an unsupported feature in an unsupported OS.