### PR TITLE
Change uninstall command from WUSA to DISM

### DIFF
--- a/memdocs/intune/apps/apps-win32-deploy-update-package.md
+++ b/memdocs/intune/apps/apps-win32-deploy-update-package.md
@@ -52,8 +52,8 @@ The following steps help you deploy a Windows update package to Intune.
 
     **Uninstall command:**  
 
-    `wusa.exe /uninstall /kb:<KB number> /quiet`
-
+    `dism.exe /online /remove-package /packagename:<Package Identity> /quiet /norestart`
+    
     The following image provides an example of the **Program** page:
 
     :::image type="content" source="./media/apps-win32-deploy-update-package/apps-win32-deploy-update-package-01.png" alt-text="Example of editing commands.":::


### PR DESCRIPTION
Starting Windows 10 version 1507, the wusa usage to quietly uninstall an update has been deprecated. The uninstall command with /quiet switch fails with event ID 8 in the Setup event log. see https://docs.microsoft.com/en-us/windows/deployment/planning/windows-10-deprecated-features