### PR TITLE
Add alternative name Intune Administrator

### DIFF
--- a/memdocs/intune/remote-actions/device-passcode-reset.md
+++ b/memdocs/intune/remote-actions/device-passcode-reset.md
@@ -63,7 +63,7 @@ To create a new work profile passcode, use the Reset Passcode action. This actio
 ## Reset a passcode
 
 
-1. Sign in to the [Microsoft Endpoint Manager admin center](https://go.microsoft.com/fwlink/?linkid=2109431) with any of the following roles: Azure Active Directory Global Admin, Azure Active Directory Intune Service Admin, Helpdesk Operator, or Role Administrator.
+1. Sign in to the [Microsoft Endpoint Manager admin center](https://go.microsoft.com/fwlink/?linkid=2109431) with any of the following roles: Azure Active Directory Global Admin, Azure Active Directory Intune Service Admin (also known as Intune Administrator), Helpdesk Operator, or Role Administrator.
 2. Select **Devices**, and then select **All devices**.
 3. From the list of devices you manage, select a device, and choose **Reset passcode**.
 


### PR DESCRIPTION
Azure Active Directory Intune Service Admin is also known as Intune Administrator under Privileged Identity Management (and probably other Azure services).
This would make it a bit easier to find.