### PR TITLE
Update azure-services-wizard.md

### DIFF
--- a/memdocs/configmgr/core/servers/deploy/configure/azure-services-wizard.md
+++ b/memdocs/configmgr/core/servers/deploy/configure/azure-services-wizard.md
@@ -261,6 +261,9 @@ To mitigate both cases, renew the secret key.
 
 For more information on how to interact with these notifications, see [Configuration Manager console notifications](../../manage/admin-console-notifications.md).
 
+> [!NOTE]
+> You need to have at least the "Cloud Application Administrator" Azure AD role assigned to be able to renew the key.
+
 ### Renew key for created app
 
 1. In the Configuration Manager console, go to the **Administration** workspace, expand **Cloud Services**, and select the **Azure Active Directory Tenants** node.


### PR DESCRIPTION
Added "Cloud Application Administrator" role info.  The update fails with the "Application Administrator" role even though the role has more permissions than "Cloud Application Administrator".