### PR TITLE
Update enrollment-autopilot.md

### DIFF
--- a/memdocs/autopilot/enrollment-autopilot.md
+++ b/memdocs/autopilot/enrollment-autopilot.md
@@ -65,7 +65,7 @@ ms.collection:
 
       When creating expressions:
       
-      - To create a group that includes all of your Autopilot devices, enter: `(device.devicePhysicalIDs -any (_ -contains "[ZTDId]"))`.
+      - To create a group that includes all of your Autopilot devices, enter: `(device.devicePhysicalIDs -any (_ -contains "[ZTDID]"))`.
       - Intune's group tag field maps to the `OrderID` attribute on Azure AD devices. To create a group that includes all Autopilot devices with a specific group tag (the Azure AD device `OrderID`), enter: `(device.devicePhysicalIds -any (_ -eq "[OrderID]:179887111881"))`.
       - To create a group that includes all your Autopilot devices with a specific Purchase Order ID, enter: `(device.devicePhysicalIds -any (_ -eq "[PurchaseOrderId]:76222342342"))`
  


### PR DESCRIPTION
Change :  - To create a group that includes all of your Autopilot devices, enter: `(device.devicePhysicalIDs -any (_ -contains "[ZTDId]"))`.  
To:  - To create a group that includes all of your Autopilot devices, enter: `(device.devicePhysicalIDs -any (_ -contains "[ZTDID]"))`.
The parameter is case sensitive and will not work correctly if the case is not correct within the Azure AD group dynamic rule.