### PR TITLE
Remove misleading text for M365 logo change

### DIFF
--- a/memdocs/intune/apps/apps-add-office365.md
+++ b/memdocs/intune/apps/apps-add-office365.md
@@ -83,7 +83,6 @@ In this step, you provide information about the app suite. This information help
     - **Developer**: Microsoft appears as the developer.
     - **Owner**: Microsoft appears as the owner.
     - **Notes**: Enter any notes that you want to associate with this app.
-    - **Logo**: The Microsoft 365 Apps logo is displayed with the app when users browse the company portal.
 2. Click **Next** to display the **Configure app suite** page.
 
 ## Step 2 - (**Option 1**) Configure app suite using the configuration designer 


### PR DESCRIPTION
Admins are not able to change the default logo. Previous editions listed logo as something that could be changed.