### PR TITLE
Added: can a user manually sync - Update compliance-use-custom-settings.md

### DIFF
--- a/memdocs/intune/protect/compliance-use-custom-settings.md
+++ b/memdocs/intune/protect/compliance-use-custom-settings.md
@@ -124,6 +124,10 @@ Refresh the current view. If the issue persists, cancel the policy creation flow
 
 It can take up to eight hours before a noncompliant status for a device update to show compliance.
 
+### Can a user manually check for compliance after fixing an issue on a device in order to identify if the issue is resolved and compliant? 
+
+Yes, user can go to [Company Portal website](https://portal.manage.microsoft.com) and in case there is currently a non-compliant custom compliance setting displayed, user can trigger sync.
+
 ### Why aren’t additional operators and operands supported?
 
 Please contact your account manager to request the addition of specific operators and operands. They can then be considered for a future update.

--- a/memdocs/intune/protect/compliance-use-custom-settings.md
+++ b/memdocs/intune/protect/compliance-use-custom-settings.md
@@ -126,7 +126,7 @@ It can take up to eight hours before a noncompliant status for a device update t
 
 ### Can a user manually check for compliance after fixing an issue on a device in order to identify if the issue is resolved and compliant? 
 
-Yes, user can go to [Company Portal website](https://portal.manage.microsoft.com) and in case there is currently a non-compliant custom compliance setting displayed, user can trigger sync.
+Yes, a user can go to the [Company Portal website](https://portal.manage.microsoft.com) and trigger a sync to update the device status after fixing a non-compliant custom compliance setting. 
 
 ### Why aren’t additional operators and operands supported?
 


### PR DESCRIPTION
Added a new question and answer to Troubleshooting paragraph:

Q: Can a user manually check for compliance after fixing an issue on a device in order to identify if the issue is resolved and compliant? 

A: Yes, user can go to [Company Portal website](https://portal.manage.microsoft.com) and in case there is currently a non-compliant custom compliance setting displayed, user can trigger sync.