### PR TITLE
Add Warning against placing console extension assemblies in bin folder.

### DIFF
--- a/memdocs/configmgr/develop/core/servers/console/console-extension-deployment.md
+++ b/memdocs/configmgr/develop/core/servers/console/console-extension-deployment.md
@@ -27,6 +27,9 @@ The deployment of a typical Configuration Manager extension has to account for a
 |Nodes|%ProgramFiles%\Microsoft Endpoint Manager\AdminConsole\bin for the assembly<br /><br /> %*ProgramFiles*%Microsoft Endpoint Manager\AdminConsole\XmlStorage\Extensions\Nodes for the node XML files|  
 |ManagementClasses|%ProgramFiles%\Microsoft Endpoint Manager\AdminConsole\bin for the assembly<br /><br /> %ProgramFiles%Microsoft Endpoint Manager\AdminConsole\XmlStorage\Extensions\ManagementClasses for the management classes XML files|  
 
+ > [!IMPORTANT]
+> Placing your assemblies and dependencies in the %ProgramFiles%\Microsoft Endpoint Manager\AdminConsole\bin folder may create conflicts with other console extensions and prevent your extension from loading.
+ 
  You must also perform the following tasks during installing and uninstalling actions.  
 
 ## Custom Actions  


### PR DESCRIPTION
Spent several days troubleshooting exactly this.  I realize that this whole process is now deprecated in favor of the Community Hub but I assure you that other vendors will be waaaaay behind the curve here.  Suggesting using the bin folder was really not a great suggestion/design in the first place and having the docs instruct people to put their assemblies there hasn't gone well in the real world.  Too late to change it now but as I have these discussions with other vendors it'd be nice to have that warning to point to in the docs. When I worked with the team on the new Community Hub design I pushed hard to have it isolate all console assemblies to avoid this exact problem.

If both console extension A and B have dependency Y then unless they require the _exact_ save version (spoiler: they won't) then the last extension installed wins and the first is broken.