### PR TITLE
Update ios-user-enrollment.md

### DIFF
--- a/memdocs/intune/enrollment/ios-user-enrollment.md
+++ b/memdocs/intune/enrollment/ios-user-enrollment.md
@@ -53,6 +53,9 @@ For more information about the options available with User Enrollment, see [User
 
 ## Create a User Enrollment profile in Intune
 
+> [!NOTE]
+> An iOS User Enrollment profile overrides an enrollment restriction policy.
+
 An enrollment profile defines the settings applied to a group of devices during enrollment. 
 
 1. In the [Microsoft Endpoint Manager admin center](https://go.microsoft.com/fwlink/?linkid=2109431), choose **Devices** > **iOS/iPadOS** > **iOS enrollment** > **Enrollment types (preview)** > **Create profile** > **iOS/iPadOS**. This profile is where you'll indicate what enrollment experience your iOS/iPadOS and iPadOS end users will have on devices not enrolled through a corporate Apple method. If you'd like to make changes, you can edit this profile after you've created it.


### PR DESCRIPTION
Updated the document to state that an iOS User Enrollment profile overrides an enrollment restriction policy.