### PR TITLE
Update certificate-connector-prerequisites.md

### DIFF
--- a/memdocs/intune/protect/certificate-connector-prerequisites.md
+++ b/memdocs/intune/protect/certificate-connector-prerequisites.md
@@ -56,7 +56,7 @@ Requirements for the computer where you install the connector software:
 
 Requirements for PKCS certificate templates:
 
-- Certificate templates you’ll use for PKCS requests must be configured with permissions that allow the certificate connector service account to auto enroll the certificate.
+- Certificate templates you’ll use for PKCS requests must be configured with permissions that allow the certificate connector service account to enroll the certificate.
 - The certificate templates must be added to the Certification Authority (CA).
 
 > [!NOTE]


### PR DESCRIPTION
Auto enroll is not needed. A service account with enroll permissions would be enough. Auto enroll could lead to enroll unwanted certificates to other machines.