### PR TITLE
Add note to computer maintenance section.

### DIFF
--- a/memdocs/configmgr/core/understand/software-center.md
+++ b/memdocs/configmgr/core/understand/software-center.md
@@ -197,6 +197,9 @@ Specify how Software Center applies changes to software before the deadline.
 
 - **Suspend Software Center activities when my computer is in presentation mode**: This setting is enabled by default.
 
+> [!NOTE]
+> These settings are designed to be managed by end users and do not impact deployment deadlines.
+
 When instructed by your IT admin, select **Sync Policy**. This computer checks with the servers for anything new, such as applications, software updates, or operating systems.
 
 ### Remote Control


### PR DESCRIPTION
This comes up from time to time.  People look at these two settings and say "oh no, my users are going to prevent me, the admin, from running deployment on their devices."  This is followed almost immediately by "how do I manage/disable these? Why isn't there a client settings for this".

Feel free to do a better job of explaining that this is both by design and will not prevent required installations from running at their deadline.  I tried finding a more pleasing way to phrase this but ran out of talent quickly as so often happens.