### PR TITLE
Consider changing the word "must" to "should"

### DIFF
--- a/memdocs/intune/protect/windows-10-feature-updates.md
+++ b/memdocs/intune/protect/windows-10-feature-updates.md
@@ -95,11 +95,11 @@ The following are prerequisites for Intune's Feature updates for Windows 10 and 
 ## Limitations for Feature updates for Windows 10 and later policy
 
 - When you deploy a *Feature updates for Windows 10 and later* policy to a device that also receives an *Update rings for Windows 10 and later* policy, review the update ring for the following configurations:
-  - The **Feature update deferral period (days)** should be set to **0**.
+  - We recommend setting the **Feature update deferral period (days)** to **0**. This configuration ensures your feature updates are not delayed by update deferrals that might be configured in an update ring policy.
   - Feature updates for the update ring must be *running*. They must not be paused.
 
   > [!TIP]
-  > If you're using feature updates, we recommend you end use of deferrals as configured in your update rings policy. Combining update ring deferrals with feature updates policy can create complexity that might delay update installations.
+  > If you're using feature updates, we recommend you end use of deferrals as configured in your update rings policy. Combining update ring deferrals with feature updates policy can create complexity that might delay update installations.  
   >
   > For more information, see [Move from update ring deferrals to feature updates policy](../protect/windows-update-for-business-configure.md#move-from-update-ring-deferrals-to-feature-updates-policy)
 

--- a/memdocs/intune/protect/windows-10-feature-updates.md
+++ b/memdocs/intune/protect/windows-10-feature-updates.md
@@ -95,7 +95,7 @@ The following are prerequisites for Intune's Feature updates for Windows 10 and 
 ## Limitations for Feature updates for Windows 10 and later policy
 
 - When you deploy a *Feature updates for Windows 10 and later* policy to a device that also receives an *Update rings for Windows 10 and later* policy, review the update ring for the following configurations:
-  - The **Feature update deferral period (days)** must be set to **0**.
+  - The **Feature update deferral period (days)** should be set to **0**.
   - Feature updates for the update ring must be *running*. They must not be paused.
 
   > [!TIP]


### PR DESCRIPTION
Setting the Feature Update deferral value to 0 in the Update ring settings is favourable and avoids unnecessary delays or complexities when targeting the same device with a Feature Update Policy. If the device is targeted with a Feature Update Policy and the Feature Update Deferral value in the Update Ring is set to a value higher than 0 then the feature update won't be offered to the device until the deferral period (in days) has been reached.

It is my understanding that the value does not "have" to be 0 but it is best practice to set this to 0. The use of the word "must" is ambiguous and suggests that the value must be zero for the Feature Update to be offered to the device, via the Feature Update policy, to be effective.

The Tip below the suggested change, in the doc, goes part way to explain the above to the reader