### PR TITLE
Update intune-endpoints.md

### DIFF
--- a/memdocs/intune/fundamentals/intune-endpoints.md
+++ b/memdocs/intune/fundamentals/intune-endpoints.md
@@ -45,6 +45,9 @@ To manage devices behind firewalls and proxy servers, you must enable communicat
 - The proxy server must support both **HTTP (80)** and **HTTPS (443)** because Intune clients use both protocols. Windows Information Protection uses port 444.
 - For some tasks (like downloading software updates for the classic pc agent), Intune requires unauthenticated proxy server access to manage.microsoft.com
 
+> [!NOTE]
+> The inspection of SSL traffic is not supported to 'manage.microsoft.com' endpoint.
+
 You can modify proxy server settings on individual client computers. You can also use Group Policy settings to change settings for all client computers located behind a specified proxy server.
 
 


### PR DESCRIPTION
Added a note that the SSL inspection of traffic to 'manage.microsoft.com' endpoint is not supported. The issue was reported after discussing with a PM internally.