### PR TITLE
Fix Automatic Superseded Version Upgrade wording.

### DIFF
--- a/memdocs/configmgr/apps/deploy-use/deploy-applications.md
+++ b/memdocs/configmgr/apps/deploy-use/deploy-applications.md
@@ -107,7 +107,7 @@ On the **Deployment Settings** page, specify the following information:
 
 - **Allow clients on a metered Internet connection to download content after the installation deadline, which might incur additional costs**: This option is only available for deployments with a purpose of **Required**.
 
-- **Automatically upgrade any superseded version of this application**: The client upgrades any superseded version of the application with the superseding application.
+- **Automatically upgrade any superseded versions of this application**: The client upgrades any superseded version of the application with the superseding application.
 
     > [!NOTE]
     > This option works regardless of administrator approval. If an administrator already approved the superseded version, they don't need to also approve the superseding version. Approval is only for new requests, not superseding upgrades.<!--515824-->


### PR DESCRIPTION
The docs were singular whereas the console is plural thus breaking search engine discovery.  That aggression can not stand. Man.