### PR TITLE
Fix Delete Unused Application Revisions

### DIFF
--- a/memdocs/configmgr/core/servers/manage/reference-for-maintenance-tasks.md
+++ b/memdocs/configmgr/core/servers/manage/reference-for-maintenance-tasks.md
@@ -68,7 +68,7 @@ Use this task to delete aged application requests from the database. For more in
 |**Primary site**|Enabled|
 |Secondary site|Not available|
 
-### Delete Aged Application Revisions
+### Delete Unused Application Revisions
 
 Use this task to delete application revisions that are no longer referenced. For more information, see [How to revise and supersede applications](../../../apps/deploy-use/revise-and-supersede-applications.md).
 


### PR DESCRIPTION
Not sure if this changed but my CB 2203 console lists this as "Delete Unused Application Revisions", not "Delete Aged Application Revisions"