### PR TITLE
DeviceId not supported for COPE devices

### DIFF
--- a/memdocs/intune/protect/certificates-profile-scep.md
+++ b/memdocs/intune/protect/certificates-profile-scep.md
@@ -129,7 +129,7 @@ Devices that run Android Enterprise might require a PIN before SCEP can provisio
        - **CN={{UserName}}**: The user name of the user, such as janedoe.
        - **CN={{UserPrincipalName}}**: The user principal name of the user, such as janedoe@contoso.com.
        - **CN={{AAD_Device_ID}}**: An ID assigned when you register a device in Azure Active Directory (AD). This ID is typically used to authenticate with Azure AD.
-       - **CN={{DeviceId}}**: An ID assigned when you enroll a device in Intune.
+       - **CN={{DeviceId}}**: An ID assigned when you enroll a device in Intune. *(not supported on Android Enterprise for Fully Managed, Dedicated, and Corporate-Owned Work Profile)*
        - **CN={{SERIALNUMBER}}**: The unique serial number (SN) typically used by the manufacturer to identify a device.
        - **CN={{IMEINumber}}**: The International Mobile Equipment Identity (IMEI) unique number used to identify a mobile phone.
        - **CN={{OnPrem_Distinguished_Name}}**: A sequence of relative distinguished names separated by comma, such as *CN=Jane Doe,OU=UserAccounts,DC=corp,DC=contoso,DC=com*.
@@ -155,7 +155,7 @@ Devices that run Android Enterprise might require a PIN before SCEP can provisio
        Format options for the Subject name format include the following variables:
 
        - **{{AAD_Device_ID}}** or **{{AzureADDeviceId}}** - Either variable can be used to identify a device by its Azure AD ID.
-       - **{{DeviceId}}** - The Intune device ID
+       - **{{DeviceId}}** - The Intune device ID *(not supported on Android Enterprise for Fully Managed, Dedicated, and Corporate-Owned Work Profile)*
        - **{{Device_Serial}}**
        - **{{Device_IMEI}}**
        - **{{SerialNumber}}**


### PR DESCRIPTION
As mentioned in MS support case 29532992, Intune does not support CN={{DeviceID}} on Android Enterprise for Fully Managed, Dedicated, and Corporate-Owned Work Profile.