### PR TITLE
Update CMPivot.md color saturation info

### DIFF
--- a/memdocs/configmgr/core/servers/manage/cmpivot.md
+++ b/memdocs/configmgr/core/servers/manage/cmpivot.md
@@ -138,6 +138,8 @@ The CMPivot window contains the following elements:
 
    - The available columns vary based upon the entity and the query.  
 
+   - The color saturation of the data in the results table or chart indicates if the data is live or from the last hardware inventory scan stored in the site database.  For example, black is real-time data from an online client whereas grey is cached data.
+
    - Select a column name to sort the results by that property.  
 
    - Right-click on any column name to group the results by the same information in that column, or sort the results.  


### PR DESCRIPTION
Add information regarding the color saturation of the data in the results being live or caches from the last hardware inventory scan stored in the site database.

Reference the [MEM Customer Connection Program discussion forum](https://teams.microsoft.com/l/message/19:2ccf7e2927d64cd6a08954741ab72057@thread.tacv2/1652889932429?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=fb6d5344-32ec-4fec-ad23-b7ffc11ffb94&parentMessageId=1652889932429&teamName=MEM%20Customer%20Connection%20Program%20(NDA)&channelName=Discussion%20Forum&createdTime=1652889932429) and a list of [CMPivot changes](https://docs.microsoft.com/en-us/mem/configmgr/core/servers/manage/cmpivot-changes#bkmk_cmpivot-hinv).