### PR TITLE
Update windows-bulk-enroll.md

### DIFF
--- a/memdocs/intune/enrollment/windows-bulk-enroll.md
+++ b/memdocs/intune/enrollment/windows-bulk-enroll.md
@@ -70,6 +70,8 @@ Azure AD users are standard users on these devices and receive assigned Intune p
 6. Select **Enroll in Azure AD**, enter a **Bulk Token Expiry** date, and then select **Get Bulk Token**. The token validity period is 180 days.
    ![Screenshot of account management in the Windows Configuration Designer app](./media/windows-bulk-enroll/bulk-enroll-account.png)
 
+[!NOTE] Once a provisioning package is created, it can be revoked before its expiration by removing the associated package_{GUID} user account from Azure AD.
+
 7. Provide your Azure AD credentials to get a bulk token.
    ![Screenshot of signing in to the Windows Configuration Designer app](./media/windows-bulk-enroll/bulk-enroll-cred.png)
 

--- a/memdocs/intune/enrollment/windows-bulk-enroll.md
+++ b/memdocs/intune/enrollment/windows-bulk-enroll.md
@@ -70,7 +70,8 @@ Azure AD users are standard users on these devices and receive assigned Intune p
 6. Select **Enroll in Azure AD**, enter a **Bulk Token Expiry** date, and then select **Get Bulk Token**. The token validity period is 180 days.
    ![Screenshot of account management in the Windows Configuration Designer app](./media/windows-bulk-enroll/bulk-enroll-account.png)
 
-[!NOTE] Once a provisioning package is created, it can be revoked before its expiration by removing the associated package_{GUID} user account from Azure AD.
+> [!NOTE]
+> Once a provisioning package is created, it can be revoked before its expiration by removing the associated package_{GUID} user account from Azure AD.
 
 7. Provide your Azure AD credentials to get a bulk token.
    ![Screenshot of signing in to the Windows Configuration Designer app](./media/windows-bulk-enroll/bulk-enroll-cred.png)


### PR DESCRIPTION
Our public docs does not contain any information on how to revoke a provisioning package after it is created. This is explained in the blog post below:
https://techcommunity.microsoft.com/t5/intune-customer-success/bulk-join-a-windows-device-to-azure-ad-and-microsoft-endpoint/ba-p/2381400#:~:text=This%20is%20the%20placeholder%20account%20used%20for%20joining%20the%20devices%2C%20and%20an%20easy%20way%20of%20invalidating%20the%20provisioning%20package%20before%20it%20expires%20automatically%20would%20be%20to%20remove%20this%20account.