### PR TITLE
Update command-line-script-file.md

### DIFF
--- a/memdocs/configmgr/core/servers/deploy/install/command-line-script-file.md
+++ b/memdocs/configmgr/core/servers/deploy/install/command-line-script-file.md
@@ -125,8 +125,8 @@ Include the following keys in the `SABranchOptions` section to install a site:<!
 
 | Key name | Required | Values | Details |
 |----------|----------|--------|---------|
-| `SAActive` | No | - `0`: You don't have SA<br>- `1`: SA is active | Specify if you have active Software Assurance (SA). For more information, see [Product and licensing FAQ](../../../understand/product-and-licensing-faq.yml). |
-| `CurrentBranch` | No | - `0`: Install the LTSB<br>- `1`: Install current branch | Specify whether to use Configuration Manager current branch or long-term servicing branch (LTSB). For more information, see [Which branch of Configuration Manager should I use?](../../../understand/which-branch-should-i-use.md) |
+| `SAActive` | Yes | - `0`: You don't have SA<br>- `1`: SA is active | Specify if you have active Software Assurance (SA). For more information, see [Product and licensing FAQ](../../../understand/product-and-licensing-faq.yml). |
+| `CurrentBranch` | Yes | - `0`: Install the LTSB<br>- `1`: Install current branch | Specify whether to use Configuration Manager current branch or long-term servicing branch (LTSB). For more information, see [Which branch of Configuration Manager should I use?](../../../understand/which-branch-should-i-use.md) |
 | `SAExpiration` | No | Date | The date when SA expires, used as a convenient reminder of that date. For more information, see [Licensing and branches](../../../understand/learn-more-editions.md). |
 
 ### `HierarchyExpansionOption` section for site expansion


### PR DESCRIPTION
Starting with ConfigMgr 2203 the SAActive and CurrentBranch keys in the SABranchOptions section are required. If you skip them, you'll see the following error in the ConfigMgrSetup.log. These keys are not required in earlier ConfigMgr versions.

ERROR: Error reading branch status. SAActive and CurrentBranch needs to be specified when installing a CAS or standalone primary site.  

