### PR TITLE
Adding a few more scenarios

### DIFF
--- a/memdocs/intune/enrollment/enrollment-restrictions-set.md
+++ b/memdocs/intune/enrollment/enrollment-restrictions-set.md
@@ -267,7 +267,8 @@ When you create a restriction, it's added to the list just above the default. Yo
 
 >[!NOTE]
 >Enrollment restrictions are applied to users. For enrollment scenarios that are not user-driven such as Windows Autopilot self-deploying mode, Bulk enrollment (WCD), or Azure Virtual desktop, Intune only enforces the default restrictions targeted to all users.
->For a succesful enrollment, make sure the platform is allowed in the default enrollment restriction policy.
+>
+>For a successful enrollment, make sure the platform is allowed in the default enrollment restriction policy.
  
 
 ## View enrollment reports

--- a/memdocs/intune/enrollment/enrollment-restrictions-set.md
+++ b/memdocs/intune/enrollment/enrollment-restrictions-set.md
@@ -266,7 +266,8 @@ When you create a restriction, it's added to the list just above the default. Yo
 
 
 >[!NOTE]
->Enrollment restrictions are applied to users. For enrollment scenarios that are not user-driven, such as Windows Autopilot self-deploying mode, Intune only enforces the default restrictions targeted to all users.  
+>Enrollment restrictions are applied to users. For enrollment scenarios that are not user-driven such as Windows Autopilot self-deploying mode, Bulk enrollment (WCD), or Azure Virtual desktop, Intune only enforces the default restrictions targeted to all users.
+>For a succesful enrollment, make sure the platform is allowed in the default enrollment restriction policy.
  
 
 ## View enrollment reports


### PR DESCRIPTION
I'm expanding the note in line #269 to clarify why is so important to make sure the platform is allowed in the default enrollment restriction policy for useless scenarios.