### PR TITLE
Update Exception Information for D4C

### DIFF
--- a/memdocs/intune/protect/includes/security-config-mgt-prerequisites.md
+++ b/memdocs/intune/protect/includes/security-config-mgt-prerequisites.md
@@ -61,7 +61,7 @@ To use security management for Microsoft Defender for Endpoint, you need:
 - A subscription that grants licenses for Microsoft Defender for Endpoint, like Microsoft 365, or a standalone license for only Microsoft Defender for Endpoint. A subscription that grants Microsoft Defender for Endpoint licenses also grants your tenant access to the Endpoint security node of the Microsoft Endpoint Manager admin center.
 
   > [!NOTE]  
-  > **Exception**: If you have access to Microsoft Defender for Endpoint as part of a Microsoft Defender for Cloud only license (formerly Azure Security Center), the Security Management for Microsoft Defender for Endpoint functionality isn't available.
+  > **Exception**: If you have access to Microsoft Defender for Endpoint as part of a Microsoft Defender for Cloud - Defender for Servers P2 (formerly Azure Security Center), the Security Management for Microsoft Defender for Endpoint functionality isn't available for clients leveraging the Log Analytics Agent.
 
   The Endpoint security node is where you'll configure and deploy policies to manage Microsoft Defender for Endpoint for your devices and monitor device status.
 


### PR DESCRIPTION
Information related to Defender for Cloud - Defender for Servers functionality being unavailable is incorrect. This dependency is linked to the agent leverage in Defender for Cloud - Defender for Servers (Unified Solution Agent), This is the default option in Defender for Servers P1 and has now been recently added to Defender for Servers P2 (Our original plan) - https://techcommunity.microsoft.com/t5/microsoft-defender-for-cloud/defender-for-servers-plan-2-now-integrates-with-mde-unified/ba-p/3527534

I have updated this exception to mention the SKU of Defender for Cloud and Agent Type which doesn't allowed for this functionality. Please feel free to change but it needs to be correct, I have had two partners reach out to me regarding this.