### PR TITLE
Update app-protection-policy-settings-android.md

### DIFF
--- a/memdocs/intune/apps/app-protection-policy-settings-android.md
+++ b/memdocs/intune/apps/app-protection-policy-settings-android.md
@@ -36,7 +36,7 @@ This article describes the app protection policy settings for Android devices. T
 There are three categories of policy settings: data protection settings, access requirements, and conditional launch. In this article, the term *policy-managed apps* refers to apps that are configured with app protection policies.
 
 > [!IMPORTANT]
-> The Intune Company Portal is required on the device to receive App Protection Policies for Android devices. 
+> Either the Intune Company Portal or the Microsoft Authenticator is required on the device to receive App Protection Policies for Android devices. 
 >
 > The Intune Managed Browser has been retired. Use [Microsoft Edge](../apps/manage-microsoft-edge.md) for your protected Intune browser experience. 
 


### PR DESCRIPTION
The following Microsoft article states, "The broker app can be the Microsoft Authenticator for iOS, or either the Microsoft Authenticator or Microsoft Company portal for Android devices. If a broker app isn’t installed on the device when the user attempts to authenticate, the user gets redirected to the appropriate app store to install the required broker app."

https://docs.microsoft.com/en-us/azure/active-directory/conditional-access/concept-conditional-access-grant#require-approved-client-app