### PR TITLE
Document is out of date

### DIFF
--- a/memdocs/intune/enrollment/apple-mdm-push-certificate-get.md
+++ b/memdocs/intune/enrollment/apple-mdm-push-certificate-get.md
@@ -66,9 +66,6 @@ Select **Download your CSR** to download and save the request file locally. The 
 7. On the confirmation page, select **Download**.  The certificate file (.pem) downloads to your device. Save this file for later.   
 
 > [!NOTE]
-> The certificate may download as a .cer file. Rename this file to .pem before uploading to Microsoft Endpoint Manager.
-
-> [!NOTE]
 > The certificate is associated with the Apple ID used to create it. As a best practice, use a company email address as your Apple ID and make sure the mailbox is monitored by more than one person, such as by a distribution list. Avoid using a personal Apple ID.  
 
 #### Managed Apple ID  
@@ -79,7 +76,7 @@ Return to the admin center and enter your Apple ID as a reminder for when you ne
 
 ### Step 5. Browse to your Apple MDM push certificate to upload
 1. Select the **Folder** icon. 
-2. Select the certificate file you downloaded in the Apple portal. 
+2. Select the certificate file (.pem) you downloaded in the Apple portal. 
 3. Select **Upload** to finish configuring the MDM push certificate. 
 
 ## Renew Apple MDM push certificate

--- a/memdocs/intune/enrollment/apple-mdm-push-certificate-get.md
+++ b/memdocs/intune/enrollment/apple-mdm-push-certificate-get.md
@@ -66,6 +66,9 @@ Select **Download your CSR** to download and save the request file locally. The 
 7. On the confirmation page, select **Download**.  The certificate file (.pem) downloads to your device. Save this file for later.   
 
 > [!NOTE]
+> The certificate may download as a .cer file. Rename this file to .pem before uploading to Microsoft Endpoint Manager.
+
+> [!NOTE]
 > The certificate is associated with the Apple ID used to create it. As a best practice, use a company email address as your Apple ID and make sure the mailbox is monitored by more than one person, such as by a distribution list. Avoid using a personal Apple ID.  
 
 #### Managed Apple ID  


### PR DESCRIPTION
The apple push certificates portal no longer downloads the certificate as .PEM ... it now downloads as .CER and needs to be renamed to .PEM in order to circumvent this check: 

![image](https://user-images.githubusercontent.com/77751400/186207420-e680e39f-f197-474a-8d99-2a9a6ee00ce7.png)
