### PR TITLE
 Update Show/Hide Device to Device Migration

### DIFF
--- a/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
+++ b/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
@@ -347,7 +347,7 @@ Now that you've installed your token, you can create an enrollment profile for A
     | **Software Update** | Display the mandatory software update screen. For iOS/iPadOS 12.0 and later. |  
     | **Watch Migration** | Give the user the option to migrate data from a watch device. For iOS/iPadOS 11.0 and later.|
     | **Appearance** | Display the Appearance screen. For macOS 10.14 and later, and iOS/iPadOS 13.0 and later. |  
-    | **Device to Device Migration** | Give the user the option to migrate data from an old device to this device. For iOS/iPadOS 13.0 and later. This setting does not have an effect on devices running iOS/iPadOS 13.0 and later that are already enrolled. On such devices, the Apps & Data screen does not display the option for device-to-device transfer. The Quick Start screen may indicate that Quick Start can do a device-to-device migration; however, if run, it will finish immediately without transferring any data.
+    | **Device to Device Migration** | Give the user the option to migrate data from an old device to this device. This feature isn't available for ADE devices running iOS 13 and later, so this screen won't appear on those devices.  
     | **Restore Completed** | Shows users the Restore Completed screen after a backup and restore is performed during Setup Assistant. |  
     | **Software Update Completed** | Shows the user all software updates that happen during Setup Assistant.|  
     | **Get Started**| Shows users the Get Started welcome screen.  

--- a/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
+++ b/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
@@ -347,7 +347,7 @@ Now that you've installed your token, you can create an enrollment profile for A
     | **Software Update** | Display the mandatory software update screen. For iOS/iPadOS 12.0 and later. |  
     | **Watch Migration** | Give the user the option to migrate data from a watch device. For iOS/iPadOS 11.0 and later.|
     | **Appearance** | Display the Appearance screen. For macOS 10.14 and later, and iOS/iPadOS 13.0 and later. |  
-    | **Device to Device Migration** | On destination devices with iOS/iPadOS 13.0 and later that are already enrolled with Apple, this setting does not have an effect. On such devices, the Apps & Data screen does not display the option to do a device to device transfer. Furthermore,the Quick Start screen may indicate that Quick Start can do a device to device migration, however, if run, it will finish immediately without transfering any data.
+    | **Device to Device Migration** | On destination devices with iOS/iPadOS 13.0 and later that are already enrolled with Apple, this setting does not have an effect. On such devices, the Apps & Data screen does not display the option to do a device-to-device transfer. Furthermore, the Quick Start screen may indicate that Quick Start can do a device-to-device migration, however, if run, it will finish immediately without transferring any data.
     | **Restore Completed** | Shows users the Restore Completed screen after a backup and restore is performed during Setup Assistant. |  
     | **Software Update Completed** | Shows the user all software updates that happen during Setup Assistant.|  
     | **Get Started**| Shows users the Get Started welcome screen.  

--- a/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
+++ b/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
@@ -347,7 +347,7 @@ Now that you've installed your token, you can create an enrollment profile for A
     | **Software Update** | Display the mandatory software update screen. For iOS/iPadOS 12.0 and later. |  
     | **Watch Migration** | Give the user the option to migrate data from a watch device. For iOS/iPadOS 11.0 and later.|
     | **Appearance** | Display the Appearance screen. For macOS 10.14 and later, and iOS/iPadOS 13.0 and later. |  
-    | **Device to Device Migration** | On destination devices with iOS/iPadOS 13.0 and later that are already enrolled with Apple, this setting does not have an effect. On such devices, the Apps & Data screen does not display the option to do a device-to-device transfer. Furthermore, the Quick Start screen may indicate that Quick Start can do a device-to-device migration, however, if run, it will finish immediately without transferring any data.
+    | **Device to Device Migration** | Give the user the option to migrate data from an old device to this device. For iOS/iPadOS 13.0 and later. This setting does not have an effect on devices running iOS/iPadOS 13.0 and later that are already enrolled. On such devices, the Apps & Data screen does not display the option for device-to-device transfer. The Quick Start screen may indicate that Quick Start can do a device-to-device migration; however, if run, it will finish immediately without transferring any data.
     | **Restore Completed** | Shows users the Restore Completed screen after a backup and restore is performed during Setup Assistant. |  
     | **Software Update Completed** | Shows the user all software updates that happen during Setup Assistant.|  
     | **Get Started**| Shows users the Get Started welcome screen.  

--- a/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
+++ b/memdocs/intune/enrollment/device-enrollment-program-enroll-ios.md
@@ -347,7 +347,7 @@ Now that you've installed your token, you can create an enrollment profile for A
     | **Software Update** | Display the mandatory software update screen. For iOS/iPadOS 12.0 and later. |  
     | **Watch Migration** | Give the user the option to migrate data from a watch device. For iOS/iPadOS 11.0 and later.|
     | **Appearance** | Display the Appearance screen. For macOS 10.14 and later, and iOS/iPadOS 13.0 and later. |  
-    | **Device to Device Migration** | Give the user the option to migrate data from an old device to this device. For iOS/iPadOS 13.0 and later. |
+    | **Device to Device Migration** | On destination devices with iOS/iPadOS 13.0 and later that are already enrolled with Apple, this setting does not have an effect. On such devices, the Apps & Data screen does not display the option to do a device to device transfer. Furthermore,the Quick Start screen may indicate that Quick Start can do a device to device migration, however, if run, it will finish immediately without transfering any data.
     | **Restore Completed** | Shows users the Restore Completed screen after a backup and restore is performed during Setup Assistant. |  
     | **Software Update Completed** | Shows the user all software updates that happen during Setup Assistant.|  
     | **Get Started**| Shows users the Get Started welcome screen.  


### PR DESCRIPTION
**Show/Hide Device to Device Migration** has no effect on destination devices with iOS/iPadOS 13.0 and later that are already enrolled with Apple. The option will not be shown on the destination device. If this information were published in the docs, it may save untold hours of frustration trying to make the option show up 😃  It seems to have been an issue since 2019 or so.

Sources
 - https://www.reddit.com/r/Intune/comments/dfj8vv/has_anyone_gotten_device_to_device_migration_to/
 - https://developer.apple.com/forums/thread/123433
 - https://social.technet.microsoft.com/Forums/en-US/9faf8e23-3bfe-4b0e-90d9-51bf2a3c40b0/device-to-device-migration?forum=microsoftintuneprod
 - Edit: I found this additional source on 08/26: https://github.com/MicrosoftDocs/IntuneDocs/issues/3029
 - Personal experience

Regards,
Urbs3w