### PR TITLE
Changing the Use Intune RBAC option requires GA role

### DIFF
--- a/memdocs/configmgr/cloud-attach/use-intune-rbac.md
+++ b/memdocs/configmgr/cloud-attach/use-intune-rbac.md
@@ -59,7 +59,7 @@ To use Intune role-based access control for tenant attach rather than Configurat
 
 To enable Intune to manage user permissions for cloud-attached devices, use the following steps:  
 
-1. Open the [Microsoft Endpoint admin center](https://endpoint.microsoft.com) and sign in as a user with the **Global Admin** role.
+1. Open the [Microsoft Endpoint admin center](https://endpoint.microsoft.com) and sign in as a user that has the **Roles/Update** permission. For more information about the permission, see [custom role permissions in Intune](../../intune/fundamentals/create-custom-role.md).
 1. Select **Tenant administration** > **Connectors and tokens** > **Microsoft Endpoint Configuration Manager**.
 1. In the banner, select **You can also manage user permissions from Intune. Click here to learn more about this option.**
 1. The **Use Intune RBAC** flyout appears.

--- a/memdocs/configmgr/cloud-attach/use-intune-rbac.md
+++ b/memdocs/configmgr/cloud-attach/use-intune-rbac.md
@@ -59,7 +59,7 @@ To use Intune role-based access control for tenant attach rather than Configurat
 
 To enable Intune to manage user permissions for cloud-attached devices, use the following steps:  
 
-1. Open the [Microsoft Endpoint admin center](https://endpoint.microsoft.com) and sign in.
+1. Open the [Microsoft Endpoint admin center](https://endpoint.microsoft.com) and sign in as a user with the **Global Admin** role.
 1. Select **Tenant administration** > **Connectors and tokens** > **Microsoft Endpoint Configuration Manager**.
 1. In the banner, select **You can also manage user permissions from Intune. Click here to learn more about this option.**
 1. The **Use Intune RBAC** flyout appears.


### PR DESCRIPTION
Hi,

I added info that you need to have a global admin role to change Use Intune RBAC option. You don't even see the flyout if you don't have the role.

Panu