### PR TITLE
Update remote-help.md

### DIFF
--- a/memdocs/intune/remote-actions/remote-help.md
+++ b/memdocs/intune/remote-actions/remote-help.md
@@ -343,6 +343,9 @@ Remote help is supported in the following languages:
 - Swedish
 - Turkish
 
+> [!NOTE] 
+> The message function of Remote Help only supports single byte characters as the current limit.
+
 ## Known Issues
 
 - When setting a conditional access policy for apps **Office 365** and **Office 365 SharePoint Online** with the grant set to **Require device to be marked as compliant**, if a user's device is either unenrolled or non-compliant, then the remote help session won’t be established. 

--- a/memdocs/intune/remote-actions/remote-help.md
+++ b/memdocs/intune/remote-actions/remote-help.md
@@ -344,7 +344,7 @@ Remote help is supported in the following languages:
 - Turkish
 
 > [!NOTE] 
-> The message function of remote help only supports single-byte characters as the current limit.
+> The Message function in Remote help only supports single byte characters.
 
 ## Known Issues
 

--- a/memdocs/intune/remote-actions/remote-help.md
+++ b/memdocs/intune/remote-actions/remote-help.md
@@ -344,7 +344,7 @@ Remote help is supported in the following languages:
 - Turkish
 
 > [!NOTE] 
-> The message function of Remote Help only supports single byte characters as the current limit.
+> The message function of remote help only supports single-byte characters as the current limit.
 
 ## Known Issues
 


### PR DESCRIPTION
updated a note stating that The message function of Remote Help only supports single byte characters as the current limit.

per issue#https://github.com/MicrosoftDocs/memdocs/issues/3179