### PR TITLE
Revoke third-party SCEP certs

### DIFF
--- a/memdocs/intune/protect/remove-certificates.md
+++ b/memdocs/intune/protect/remove-certificates.md
@@ -49,6 +49,9 @@ Manual deletion of a certificate is a scenario that applies across platforms and
 
 In this scenario, after the certificate is deleted, the next time the device checks in with Intune it's found to be out of compliance as it is missing the expected certificate. Intune then issues a new certificate to restore the device to compliance. No other action is needed to restore the certificate.
 
+> [!NOTE]
+> SCEP certificates are [removed but not revoked](../certificate-authority-add-scep-overview#removing-certificates) when using a using a third-party certification authority.
+
 ## Windows devices
 
 ### SCEP certificates

--- a/memdocs/intune/protect/remove-certificates.md
+++ b/memdocs/intune/protect/remove-certificates.md
@@ -50,7 +50,7 @@ Manual deletion of a certificate is a scenario that applies across platforms and
 In this scenario, after the certificate is deleted, the next time the device checks in with Intune it's found to be out of compliance as it is missing the expected certificate. Intune then issues a new certificate to restore the device to compliance. No other action is needed to restore the certificate.
 
 > [!NOTE]
-> SCEP certificates are [removed but not revoked](../certificate-authority-add-scep-overview#removing-certificates) when using a using a third-party certification authority.
+> SCEP certificates are [removed but not revoked](../certificate-authority-add-scep-overview#removing-certificates) when using a third-party certification authority.
 
 ## Windows devices
 


### PR DESCRIPTION
Added note and reference to call out that third-party SCEP certs are removed but not revoked.