### PR TITLE
Update customer-permissions.md

### DIFF
--- a/windows-365/enterprise/customer-permissions.md
+++ b/windows-365/enterprise/customer-permissions.md
@@ -45,8 +45,6 @@ You create ANCs to define the connection between your network and the Windows 36
 - **Network contributor on the specified resource group**: This permission is used to create network interface cards in the selected resource group.
 - **Network contributor on the virtual network**: This permission is used to attach the created network interface cards to the selected virtual network. 
 
-
-
 > [!TIP]
 > When you use [Microsoft hosted network option](architecture.md#virtual-network-connectivity) with a gallery image, the Windows 365 service principal does not require these permissions.
 

--- a/windows-365/enterprise/customer-permissions.md
+++ b/windows-365/enterprise/customer-permissions.md
@@ -39,16 +39,16 @@ Windows 365 uses the Azure role-based access control (RBAC) permissions required
 
 ## Create Azure network connections
 
-You create ANCs to define the connection between your network and the Windows 365 system so that Cloud PCs can be successfully provisioned. When you create an ANC, the Windows 365 [service principal](/azure/active-directory/fundamentals/service-accounts-introduction-azure.md#service-principals) requires the following permissions:
+You create ANCs to define the connection between your network and the Windows 365 system so that Cloud PCs can be successfully provisioned. When you create an ANC, you must be signed in with an account that is an Owner or admin of the subscription. During ANC setup, the Windows 365 [service principal](/azure/active-directory/fundamentals/service-accounts-introduction-azure.md#service-principals) is automatically assigned the following permissions:
 
 - **Reader permission on the Azure subscription**: This permission is used to simplify the flow when adding a custom image.
 - **Network contributor on the specified resource group**: This permission is used to create network interface cards in the selected resource group.
 - **Network contributor on the virtual network**: This permission is used to attach the created network interface cards to the selected virtual network. 
 
-When you create an ANC, you must be signed in with an account that is an Owner of the subscription. 
+
 
 > [!TIP]
-> When you use [Microsoft hosted network option](architecture.md#virtual-network-connectivity) with a gallery image, you do not need to grant the Windows 365 service principal these permissions.
+> When you use [Microsoft hosted network option](architecture.md#virtual-network-connectivity) with a gallery image, the Windows 365 service principal does not require these permissions.
 
 For more information, see [Create Azure network connection](create-azure-network-connection.md).
 

--- a/windows-365/enterprise/customer-permissions.md
+++ b/windows-365/enterprise/customer-permissions.md
@@ -39,7 +39,7 @@ Windows 365 uses the Azure role-based access control (RBAC) permissions required
 
 ## Create Azure network connections
 
-You create ANCs to define the connection between your network and the Windows 365 system so that Cloud PCs can be successfully provisioned. When you create an ANC, you must be signed in with an account that is an Owner or admin of the subscription. During ANC setup, the Windows 365 [service principal](/azure/active-directory/fundamentals/service-accounts-introduction-azure.md#service-principals) is automatically assigned the following permissions:
+You create ANCs to define the connection between your network and the Windows 365 system so that Cloud PCs can be successfully provisioned. When you create an ANC, you must be signed in with an account that is either an owner or admin of the subscription. During ANC setup, the Windows 365 [service principal](/azure/active-directory/fundamentals/service-accounts-introduction-azure.md#service-principals) is automatically assigned the following permissions:
 
 - **Reader permission on the Azure subscription**: This permission is used to simplify the flow when adding a custom image.
 - **Network contributor on the specified resource group**: This permission is used to create network interface cards in the selected resource group.


### PR DESCRIPTION
clarifying permissions are automatically assigned to the service principal during setup and the user does not need to manually grant the service principal those permissions as confirmed by Eric Orman