### PR TITLE
Update provide-localized-windows-experience.md

### DIFF
--- a/windows-365/enterprise/provide-localized-windows-experience.md
+++ b/windows-365/enterprise/provide-localized-windows-experience.md
@@ -52,10 +52,7 @@ For both the provisioning policy and custom image options to set up the display 
   - LanguagePack: https://software-download.microsoft.com/download/pr/19041.1.191206-1406.vb_release_CLIENTLANGPACKDVD_OEM_MULTI.iso
   - FOD: https://software-download.microsoft.com/download/pr/19041.1.191206-1406.vb_release_amd64fre_FOD-PACKAGES_OEM_PT1_amd64fre_MULTI.iso
   - InboxApps: https://software-download.microsoft.com/download/pr/19041.508.200905-1327.vb_release_svc_prod1_amd64fre_InboxApps.iso
-- Windows 10 1909
-  - LanguagePack: https://software-download.microsoft.com/download/pr/18362.1.190318-1202.19h1_release_CLIENTLANGPACKDVD_OEM_MULTI.iso
-  - FOD: https://software-download.microsoft.com/download/pr/18362.1.190318-1202.19h1_release_amd64fre_FOD-PACKAGES_OEM_PT1_amd64fre_MULTI.iso
-  - InboxApps: https://software-download.microsoft.com/download/pr/18362.1.190318-1202.19h1_release_amd64fre_InboxApps.iso
+
 
 ## Next steps
 

--- a/windows-365/enterprise/provide-localized-windows-experience.md
+++ b/windows-365/enterprise/provide-localized-windows-experience.md
@@ -53,7 +53,6 @@ For both the provisioning policy and custom image options to set up the display 
   - FOD: https://software-download.microsoft.com/download/pr/19041.1.191206-1406.vb_release_amd64fre_FOD-PACKAGES_OEM_PT1_amd64fre_MULTI.iso
   - InboxApps: https://software-download.microsoft.com/download/pr/19041.508.200905-1327.vb_release_svc_prod1_amd64fre_InboxApps.iso
 
-
 ## Next steps
 
 [Use a provisioning policy](use-provisioning-policy-default-display-language.md) or [create a custom device image](create-custom-image-languages.md) to set up the display language.


### PR DESCRIPTION
Removed Windows 10 19H2 version,  Only 20H2 is supported per https://learn.microsoft.com/en-us/windows-365/enterprise/device-images