### PR TITLE
Update assign-users-as-local-admin.md

### DIFF
--- a/windows-365/enterprise/assign-users-as-local-admin.md
+++ b/windows-365/enterprise/assign-users-as-local-admin.md
@@ -30,7 +30,7 @@ ms.collection: M365-identity-device-management
 
 # Make a user a local admin
 
-The **User settings** page lets IT administrators manage various settings for the user. Currently, the only setting is the option of making the user a local admin in their Cloud PC.  
+The **User settings** page lets IT administrators manage various settings for the user. 
 
 When managing settings, keep the following points in mind:
 


### PR DESCRIPTION
Removed the statement that Local Admin is the only setting that is configurable as that is no longer true.   Restores are configured under User Settings now.  See https://learn.microsoft.com/en-us/windows-365/enterprise/restore-configure

@DougCoombs perhaps https://learn.microsoft.com/en-us/windows-365/enterprise/restore-configure should have a copy or a link from under User Settings also?

![image](https://user-images.githubusercontent.com/26374704/195807560-92609b7e-3b3b-45cc-8035-0ee496a05f08.png)
