### PR TITLE
Update teams-on-cloud-pc.md

### DIFF
--- a/windows-365/enterprise/teams-on-cloud-pc.md
+++ b/windows-365/enterprise/teams-on-cloud-pc.md
@@ -55,8 +55,8 @@ Some of the key benefits of the optimizations are:
 Media optimization for Microsoft Teams is only available for the Windows and macOS endpoints. Media optimizations require:
 
 - Windows 365 app for Windows via the Microsoft Store (ideally the latest version).
-- Remote Desktop client for Windows version 1.2.1026.0 or later (ideally the latest version).
-- Remote Desktop client for macOS version 10.7.7 or later ([preview](..\public-preview.md)). If you upgrade from versions earlier than 10.7.7, you'll also need to go to Microsoft **Remote Desktop Preferences** > **General** and turn on Teams optimizations. If you're using the client for the first time and already have version 10.7.7 or later installed, you won't need to turn that on. In that case, Teams optimizations are turned on by default.
+- Remote Desktop client for Windows, version 1.2.1026.0 or later (ideally the latest version).
+- Remote Desktop client for macOS, version 10.7.7 or later ([preview](https://aka.ms/rdmacbeta). If you upgrade from versions earlier than 10.7.7, you'll also need to go to Microsoft **Remote Desktop Preferences** > **General** and turn on Teams optimizations. If you're using the client for the first time and already have version 10.7.7 or later installed, you won't need to turn that on. In that case, Teams optimizations are turned on by default.
 
 > [!NOTE]
 > Microsoft Teams installs during the first sign in to the Cloud PC. Installation can take a couple of minutes. Make sure to restart Teams to activate the AV optimizations that redirect audio and video. You can also sign out and in again to your Cloud PC to gain the same result.


### PR DESCRIPTION
- corrected URL to latest Remote Desktop client for Mac. 
- added comma to make it more clear it is referring to 10.7.7 of Remote Desktop client for Mac, and not a MAcOS version 10.7.7 or later