### PR TITLE
Fix table formatting for AppIdentitySwitchReason

### DIFF
--- a/memdocs/intune/developer/app-sdk-android-phase5.md
+++ b/memdocs/intune/developer/app-sdk-android-phase5.md
@@ -378,6 +378,7 @@ public abstract void onMAMIdentitySwitchRequired(String identity,
 ```
 
 The `AppIdentitySwitchReason` enum parameter describes the source of the implicit identity switch.
+
 | Enum value | Default SDK behavior | Description |
 | - | - | - |
 | `CREATE` | Allow the identity switch. | The identity switch is occurring because of an activity creation. | 


### PR DESCRIPTION
Without the newline, this does not render properly as a table in docs.microsoft.com (although it does render properly in Github either way)