### PR TITLE
Fix "Fast user switching" setting to the correct CSP.

### DIFF
--- a/memdocs/intune/configuration/device-restrictions-windows-10.md
+++ b/memdocs/intune/configuration/device-restrictions-windows-10.md
@@ -762,7 +762,7 @@ These settings use the [start policy CSP](/windows/client-management/mdm/policy-
 
 - **Fast user switching**: **Block** prevents switching between users that are logged on simultaneously without logging off. When set to **Not configured** (default), Intune doesn't change or update this setting. By default, the OS might show the **Switch user** on the user tile.
 
-  [Start/HideSwitchAccount CSP](/windows/client-management/mdm/policy-csp-start#start-hideswitchaccount)
+  [WindowsLogon/HideFastUserSwitching CSP](/windows/client-management/mdm/policy-csp-windowslogon#windowslogon-hidefastuserswitching)
 
 - **Most used apps**: **Block** hides the most used apps from showing on the start menu. It also disables the corresponding toggle in the Settings app. When set to **Not configured** (default), Intune doesn't change or update this setting. By default, the OS might show the most used apps.
 


### PR DESCRIPTION
Start/HideSwitchAccount CSP corresponds to "Switch Account" setting, while "Fast user switching" setting seems to use WindowsLogon/HideFastUserSwitching CSP.