### PR TITLE
Update apple-school-manager-set-up-ios.md

### DIFF
--- a/memdocs/intune/enrollment/apple-school-manager-set-up-ios.md
+++ b/memdocs/intune/enrollment/apple-school-manager-set-up-ios.md
@@ -37,7 +37,7 @@ You can set up Intune to enroll iOS/iPadOS devices purchased through the [Apple 
 
 To enable Apple School Manager enrollment, you use both the Intune and Apple School Manager portals. A list of serial numbers or a purchase order number is required so you can assign devices to Intune for management. You create Automated Device Enrollment (ADE) enrollment profiles containing settings that applied to devices during enrollment.
 
-Apple School Manager enrollment can't be used with [Apple's Automated Device Enrollment ](device-enrollment-program-enroll-ios.md) or the [device enrollment manager](device-enrollment-manager-enroll.md).
+Apple School Manager enrollment can't be used with the [device enrollment manager](device-enrollment-manager-enroll.md).
 
 **Prerequisites**
 - [Apple Mobile Device Management (MDM) Push certificate](apple-mdm-push-certificate-get.md)


### PR DESCRIPTION
When the term DEP was renamed in our docs to Automated Device Enrollment, it caused this documentation to be incorrect.  Apple School Manager enrollment absolutely works with Automated Device Enrollment. The sentence should only mention that ASM does not work with device enrollment managers.