### PR TITLE
Update to include the endpoint clients.config.office.net for M365

### DIFF
--- a/memdocs/configmgr/core/plan-design/network/internet-endpoints.md
+++ b/memdocs/configmgr/core/plan-design/network/internet-endpoints.md
@@ -182,7 +182,7 @@ If you use Configuration Manager to deploy and update Microsoft 365 Apps for ent
 
 - `contentstorage.osi.office.net` to support the evaluation of Office add-in readiness<!-- MEMDocs#410 -->
 
-- `clients.config.office.net` used to retrieve the names of the files needed for a particular Microsoft 365 Apps update. For more information, see [Using the Microsoft 365 Apps file list API](https://learn.microsoft.com/en-us/office/client-developer/shared/manageability-applications-with-the-office-365-click-to-run-installer#using-the-microsoft-365-apps-file-list-api).
+- `clients.config.office.net` to retrieve the names of the files needed for a particular Microsoft 365 Apps update. For more information, see [Using the Microsoft 365 Apps file list API](/office/client-developer/shared/manageability-applications-with-the-office-365-click-to-run-installer#using-the-microsoft-365-apps-file-list-api).
 
 Your top-level site server needs access to the following endpoint to download the Microsoft Apps 365 readiness file:
 

--- a/memdocs/configmgr/core/plan-design/network/internet-endpoints.md
+++ b/memdocs/configmgr/core/plan-design/network/internet-endpoints.md
@@ -182,6 +182,8 @@ If you use Configuration Manager to deploy and update Microsoft 365 Apps for ent
 
 - `contentstorage.osi.office.net` to support the evaluation of Office add-in readiness<!-- MEMDocs#410 -->
 
+- `clients.config.office.net` used to retrieve the names of the files needed for a particular Microsoft 365 Apps update. For more information, see [Using the Microsoft 365 Apps file list API](https://learn.microsoft.com/en-us/office/client-developer/shared/manageability-applications-with-the-office-365-click-to-run-installer#using-the-microsoft-365-apps-file-list-api).
+
 Your top-level site server needs access to the following endpoint to download the Microsoft Apps 365 readiness file:
 
 - Starting March 2, 2021: `https://omex.cdn.office.net/mirrored/sccmreadiness/SOT_SCCM_AddinReadiness.CAB`


### PR DESCRIPTION
WsyncMgr fails to sync Office updates if the endpoint is not included in the Proxy/firewall settings.