### PR TITLE
Update configure-discovery-methods.md

### DIFF
--- a/memdocs/configmgr/core/servers/deploy/configure/configure-discovery-methods.md
+++ b/memdocs/configmgr/core/servers/deploy/configure/configure-discovery-methods.md
@@ -138,7 +138,8 @@ Although each of these discovery methods is independent of the others, they shar
 4. On the **Options** tab, configure settings to filter out or exclude stale computer records from discovery. Also configure the discovery of the membership of distribution groups.  
 
     > [!NOTE]  
-    > By default, Active Directory Group Discovery discovers only the membership of security groups.  
+    > By default, Active Directory Group Discovery discovers only the membership of security groups.
+    > Even if selecting the checkbox, Configuration Manager doesn't discover the Distribution Group itself but its members and populates Distribution group - members relations in the database/
 
 5. Select **OK** to save the configuration.  
 


### PR DESCRIPTION
It's a long-standing design that the distribution group itself is not shown in the \Users list. Instead, the UserGroup property is populated in the user properties, thus allowing to create collections based on the distribution group.