### PR TITLE
Update product naming in security-config-mgt-prerequisites.md

### DIFF
--- a/memdocs/intune/protect/includes/security-config-mgt-prerequisites.md
+++ b/memdocs/intune/protect/includes/security-config-mgt-prerequisites.md
@@ -54,7 +54,7 @@ Policies for Microsoft Defender for Endpoint security management are supported f
 - Windows Server 2019 (with [KB5006744](https://support.microsoft.com/topic/october-19-2021-kb5006744-os-build-17763-2268-preview-e043a8a3-901b-4190-bb6b-f5a4137411c0))
 - Windows Server 2022 (with [KB5006745](https://support.microsoft.com/topic/october-26-2021-kb5006745-os-build-20348-320-preview-8ff9319a-19e7-40c7-bbd1-cd70fcca066c))
 
-Security management for Microsoft Defender for Endpoint will not work on non-persistent desktops, like Virtual Desktop Infrastructure (VDI) clients or Windows Virtual Desktops (WVD).
+Security management for Microsoft Defender for Endpoint will not work on non-persistent desktops, like Virtual Desktop Infrastructure (VDI) clients or Azure Virtual Desktops.
 
 ### Licensing and subscriptions
 


### PR DESCRIPTION
Windows Virtual Desktop (WVD) has since been renamed to Azure Virtual Desktop.

Source: https://azure.microsoft.com/en-us/products/virtual-desktop/ - "[...] Azure Virtual Desktop (formerly Windows Virtual Desktop) [...]" I removed the abbreviation entirely because I found no official source referring to Azure Virtual Desktop as "AVD".

Please take a look at this.