### PR TITLE
Update device-compliance-get-started.md

### DIFF
--- a/memdocs/intune/protect/device-compliance-get-started.md
+++ b/memdocs/intune/protect/device-compliance-get-started.md
@@ -86,7 +86,7 @@ Compliance policy settings include the following settings:
   - The Company Portal app opens
   - The device physically moves a significant distance, which is approximately 500 meters or more. Intune can’t guarantee that each significant location change results in a jailbreak detection check, as the check depends on a device's network connection at the time.
 
-“If an Enhanced jailbreak detection evaluation does not run for a certain period of time, the device will be marked as Jailbroken, and subsequently as Not Compliant.”
+If an Enhanced jailbreak detection evaluation does not run for a certain period of time, the device will be marked as _Jailbroken_, and subsequently as _Not Compliant_.
 
   On iOS 13 and higher, this feature requires users to select *Always Allow* whenever the device prompts them to continue allowing Company Portal to use their location in the background. If enabled, this will allow more frequent jailbreak detection checks.
 

--- a/memdocs/intune/protect/device-compliance-get-started.md
+++ b/memdocs/intune/protect/device-compliance-get-started.md
@@ -86,7 +86,7 @@ Compliance policy settings include the following settings:
   - The Company Portal app opens
   - The device physically moves a significant distance, which is approximately 500 meters or more. Intune can’t guarantee that each significant location change results in a jailbreak detection check, as the check depends on a device's network connection at the time.
 
-If an Enhanced jailbreak detection evaluation does not run for a certain period of time, the device will be marked as _Jailbroken_, and subsequently as _Not Compliant_.
+  If an Enhanced jailbreak detection evaluation does not run for a certain period of time, the device will be marked as _Jailbroken_, and subsequently as _Not Compliant_.
 
   On iOS 13 and higher, this feature requires users to select *Always Allow* whenever the device prompts them to continue allowing Company Portal to use their location in the background. If enabled, this will allow more frequent jailbreak detection checks.
 

--- a/memdocs/intune/protect/device-compliance-get-started.md
+++ b/memdocs/intune/protect/device-compliance-get-started.md
@@ -86,6 +86,8 @@ Compliance policy settings include the following settings:
   - The Company Portal app opens
   - The device physically moves a significant distance, which is approximately 500 meters or more. Intune can’t guarantee that each significant location change results in a jailbreak detection check, as the check depends on a device's network connection at the time.
 
+“If an Enhanced jailbreak detection evaluation does not run for a certain period of time, the device will be marked as Jailbroken, and subsequently as Not Compliant.”
+
   On iOS 13 and higher, this feature requires users to select *Always Allow* whenever the device prompts them to continue allowing Company Portal to use their location in the background. If enabled, this will allow more frequent jailbreak detection checks.
 
 - **Compliance status validity period (days)**


### PR DESCRIPTION
I’ve been working on a Strategic support case (33602944) with BP (British Petroleum), they this certain addition they want to incorporate.  They want to add something along the lines of: “If an Enhanced jailbreak detection evaluation does not run for a certain period of time, the device will be marked as Jailbroken, and subsequently as Not Compliant.” We’ve validated this to be correct from a technical standpoint and I could confirm this as the expected behavior for us. However, they are making the argument that the addition is needed in order to provide more clarity regarding the expected behavior. I can provide more details about the impact and the reasoning behind this request as/if needed. Do you consider this to be feasible? I’ve made my argument to them regarding this being “self-explanatory” – we don’t document logical outcomes. Nevertheless, they seem to still want to add it, for full transparency purposes.