### PR TITLE
Update reports-export-graph-available-reports.md

### DIFF
--- a/memdocs/intune/fundamentals/reports-export-graph-available-reports.md
+++ b/memdocs/intune/fundamentals/reports-export-graph-available-reports.md
@@ -53,7 +53,7 @@ The following table contains the possible values for the `reportName` parameter.
 |         DetectedAppsAggregate  |            Detected   Apps report        |
 |         FeatureUpdatePolicyFailuresAggregate  |            Under   **Devices** > **Monitor** > **Failure for feature updates**       |
 |         DeviceFailuresByFeatureUpdatePolicy  |            Under   **Devices** > **Monitor** > **Failure for feature updates** > *click   on error*        |
-|         DiscoveredAppsRawData  |            Under **Apps** > **Monitor** > **Discoverd apps** > **Export**         |
+|         DetectedAppsRawData  |            Under **Apps** > **Monitor** > **Discoverd apps** > **Export**         |
 |         FeatureUpdateDeviceState  |            Under   **Reports** > **Window Updates** > **Reports** > **Windows   Feature Update Report**         |
 |         UnhealthyDefenderAgents  |            Under   **Endpoint Security** > **Antivirus** > **Win10 Unhealthy   Endpoints**        |
 |         DefenderAgents  |            Under   **Reports** > **MicrosoftDefender** > **Reports** > **Agent   Status**        |
@@ -399,9 +399,9 @@ You can choose to filter the `DeviceFailuresByFeatureUpdatePolicy` report's outp
 - `RecommendedAction` 
 - `WindowsUpdateVersion` 
 
-## DiscoveredAppsRawData report
+## DetecteddAppsRawData report
 
-The following table contains the possible output when calling the `DiscoveredAppsRawData` report:
+The following table contains the possible output when calling the `DetectedAppsRawData` report:
 
 | Available   properties |
 |-|

--- a/memdocs/intune/fundamentals/reports-export-graph-available-reports.md
+++ b/memdocs/intune/fundamentals/reports-export-graph-available-reports.md
@@ -399,7 +399,7 @@ You can choose to filter the `DeviceFailuresByFeatureUpdatePolicy` report's outp
 - `RecommendedAction` 
 - `WindowsUpdateVersion` 
 
-## DetecteddAppsRawData report
+## DetectedAppsRawData report
 
 The following table contains the possible output when calling the `DetectedAppsRawData` report:
 


### PR DESCRIPTION
DiscoveredAppsRawData seems to have been renamed to DetectedAppsRawData. The graph API returns an error now if a request is made for the previous report name.