### PR TITLE
"MANGEDINSTALLER" is misspelled

### DIFF
--- a/memdocs/configmgr/core/clients/deploy/about-client-installation-properties.md
+++ b/memdocs/configmgr/core/clients/deploy/about-client-installation-properties.md
@@ -616,7 +616,7 @@ Example: `CCMSetup.exe IGNOREAPPVVERSIONCHECK=TRUE`
 
 If you set this property to `1` then ccmsetup.exe and client.msi are set as managed installers. For more information, see [Automatically allow apps deployed by a managed installer with Windows Defender Application Control](/windows/security/threat-protection/windows-defender-application-control/configure-authorized-apps-deployed-with-a-managed-installer).
 
-Example: `CCMSetup.exe MANGEDINSTALLER=1`
+Example: `CCMSetup.exe MANAGEDINSTALLER=1`
 
 ### `NOTIFYONLY`
 


### PR DESCRIPTION
It should be "MANAGEDINSTALLER"

// before
Example: `CCMSetup.exe MANGEDINSTALLER=1`

// after 
Example: `CCMSetup.exe MANAGEDINSTALLER=1`