### PR TITLE
Update export-import-task-sequences.md

### DIFF
--- a/memdocs/configmgr/osd/deploy-use/export-import-task-sequences.md
+++ b/memdocs/configmgr/osd/deploy-use/export-import-task-sequences.md
@@ -69,7 +69,8 @@ The wizard creates the following output files:
 
 If you include content when you export a task sequence, make sure that you copy the .zip file and the *export*_files folder, or the import fails.
 
-[!NOTE] If you have multi-site hierarchy, Export of task sequences should be done from Central Administration site because primary site may not have required permissions to all the artifacts.
+> [!NOTE]
+> If you have a multi-site hierarchy, the export of task sequences should be done from the central administration site because the primary site may not have the required permissions to all the artifacts.
 
 ## Import
 

--- a/memdocs/configmgr/osd/deploy-use/export-import-task-sequences.md
+++ b/memdocs/configmgr/osd/deploy-use/export-import-task-sequences.md
@@ -69,6 +69,8 @@ The wizard creates the following output files:
 
 If you include content when you export a task sequence, make sure that you copy the .zip file and the *export*_files folder, or the import fails.
 
+[!NOTE] If you have multi-site hierarchy, Export of task sequences should be done from Central Administration site because primary site may not have required permissions to all the artifacts.
+
 ## Import
 
 1. In the Configuration Manager console, go to the **Software Library** workspace, expand **Operating Systems**, and then select the **Task Sequences** node.


### PR DESCRIPTION
Added this note
[!NOTE] If you have multi-site hierarchy, Export of task sequences should be done from Central Administration site because primary site may not have required permissions to all the artifacts.