### PR TITLE
Update the [client-driven recovery password rotation] default value

### DIFF
--- a/memdocs/intune/protect/endpoint-protection-windows-10.md
+++ b/memdocs/intune/protect/endpoint-protection-windows-10.md
@@ -651,7 +651,7 @@ These settings apply specifically to operating system data drives.
     - **Backup recovery passwords only**  
 
   - **Client-driven recovery password rotation**  
-    **Default**: Key rotation enabled for Azure AD-joined devices  
+    **Default**: Not configured  
     BitLocker CSP: [ConfigureRecoveryPasswordRotation](/windows/client-management/mdm/bitlocker-csp)  
 
     This setting initiates a client-driven recovery password rotation after an OS drive recovery (either by using bootmgr or WinRE).  


### PR DESCRIPTION
Based on the discussion in https://portal.microsofticm.com/imp/v3/incidents/details/370842949/home, the default value of [client-driven recovery password rotation] has changed from "Key rotation enabled for Azure AD-joined devices" to "Not configured" in 2020. Updating the doc to reflect the new default value.