### PR TITLE
Unsupported Device Location Capabilities not clear

### DIFF
--- a/memdocs/intune/remote-actions/device-locate.md
+++ b/memdocs/intune/remote-actions/device-locate.md
@@ -60,7 +60,7 @@ You need to enable Windows location services in Windows Out of Box Experience (O
 - **Android Enterprise corporate-owned work profile devices** - Requires the Intune app running 2202.01 or later
 - **Android Enterprise corporate-owned fully managed devices** - Requires the Intune app running 2202.01 or later
 
-**Unsupported** - Device location capabilities aren't supported for the following platforms:
+**Unsupported** - Device location capabilities aren't supported for the following platforms: 
 
 - Android device administrator
 - Android Enterprise:


### PR DESCRIPTION
I'm trying to review the Locate device action together with a customer. Unfortunately for me it's not clear this section that mention unsupported enrollment types, but on the other hand the previous paragraph is mentioning most of the same enrollment types in particular I'm referring to Android enrollment profiles.

Unsupported - Device location capabilities aren't supported for the following platforms:

Android device administrator
Android Enterprise:
Corporate-owned work profile
Personally-owned work profile
Fully managed
macOS
Windows Holographic for Business
Windows Phone