### PR TITLE
adding note on ios remove passcode

### DIFF
--- a/memdocs/intune/remote-actions/device-passcode-reset.md
+++ b/memdocs/intune/remote-actions/device-passcode-reset.md
@@ -87,6 +87,9 @@ The temporary passcode must be entered on the device. The temporary passcode for
 
 Instead of being reset, passcodes are removed from iOS/iPadOS devices. If there's a passcode compliance policy set, the device will prompt the user to set a new passcode in Settings.
 
+> [!IMPORTANT]
+> - If the remove passcode action failed, it's possible that the wrong unlock token is stored in Intune and the device will need to be wiped in order to regain access to it. 
+
 ## Troubleshooting remote lock failures
 
 If the remote lock action failed, validate that the following have been correctly configured:


### PR DESCRIPTION
Remove passcode action sometimes fails due to Intune having the wrong unlock token, and Apple has deprecated the ability to request a new unlock token. Adding this note for guidance.