### PR TITLE
Update pre-provision.md

### DIFF
--- a/memdocs/autopilot/pre-provision.md
+++ b/memdocs/autopilot/pre-provision.md
@@ -143,7 +143,7 @@ If the pre-provisioning process completed successfully and the device was reseal
 - Power on the device.
 - Select the appropriate language, locale, and keyboard layout.
 - Connect to a network (if using Wi-Fi). Internet access is always required. If using Hybrid Azure AD Join, there must also be connectivity to a domain controller.
-- On the branded sign-on screen, enter the user's Azure Active Directory credentials.
+- On the branded sign-on screen, enter the user's Azure Active Directory credentials. If using Hybrid Azure AD Join, this sign-on screen does not appear because the user does not need to enter credentials.
 - If using Hybrid Azure AD Join, the device will reboot; after the reboot, enter the user's Active Directory credentials.
 - Additional policies and apps will be delivered to the device, as tracked by the Enrollment Status Page (ESP). Once complete, the user can access the desktop.
 


### PR DESCRIPTION
customer reported that they don't see the AAD sign-in prompt user flow for pre-provisioned hybrid devices which is by design (there's no need to ask for the AAD creds in PP hybrid flow and it was functional requirement from day 0 to skip that AAD sign-in during OOBE for hybrid). Adding note to that effect in the request.