### PR TITLE
Corect the default value for Smart card removal behavior

### DIFF
--- a/memdocs/intune/protect/endpoint-protection-windows-10.md
+++ b/memdocs/intune/protect/endpoint-protection-windows-10.md
@@ -1310,7 +1310,7 @@ Use these options to configure the local security settings on Windows 10/11 devi
   - **Not configured** - Pressing CTRL+ALT+DEL isn't required for users to sign in.
 
 - **Smart card removal behavior**  
-  **Default**: Lock workstation   
+  **Default**: No Action
   LocalPoliciesSecurityOptions CSP: [InteractiveLogon_SmartCardRemovalBehavior](/windows/client-management/mdm/policy-csp-localpoliciessecurityoptions)  
 
   Determines what happens when the smart card for a logged-on user is removed from the smart card reader. Your options:  


### PR DESCRIPTION
The default value of the Smart card removal behavior has been changed several years ago. This was confirmed in the following ICM. https://portal.microsofticm.com/imp/v3/incidents/details/375212881/home