### PR TITLE
Update reusable-settings-groups.md

### DIFF
--- a/memdocs/intune/protect/reusable-settings-groups.md
+++ b/memdocs/intune/protect/reusable-settings-groups.md
@@ -63,7 +63,7 @@ The following profiles support use of reusable settings groups:
 **Endpoint security policy**
 
 - **Antivirus** > **Microsoft Defender Firewall rules**:  
-  - Platforms: Windows 10, Windows 11, and Windows Server
+  - Platforms: Windows 10 and Windows 11
   - Windows versions: Devices must run Windows 10 20H2 or later, or Windows 11.
 
 - **Attack surface reduction** > **Device control**:


### PR DESCRIPTION
Windows Server is unsupported for reusable settings, removing Windows Server from prereqs section after confirming with PM. Ref inc 381562858 case 2302061420001653.