### PR TITLE
Update microsoft-connected-cache.md

### DIFF
--- a/memdocs/configmgr/core/plan-design/hierarchy/microsoft-connected-cache.md
+++ b/memdocs/configmgr/core/plan-design/hierarchy/microsoft-connected-cache.md
@@ -232,8 +232,10 @@ When you enable Connected Cache on your Configuration Manager distribution point
 
 - Enable the following client settings in the [**Delivery Optimization**](../../clients/deploy/about-client-settings.md#delivery-optimization) group:
 
-  - **Use Configuration Manager Boundary Groups for Delivery Optimization Group ID**
+  - **Use Configuration Manager Boundary Groups for Delivery Optimization Group ID:**
+    This option is required only if you are using Delivery Optimization's Peer-to-peer. You do not need to set this option to use Microsoft Connected Cache.
   - **Enable devices managed by Configuration Manger to use Microsoft Connected Cache servers for content download**
+    
 
 - Enable co-management, and switch the **Client apps** workload to **Pilot Intune** or **Intune**. For more information, see the following articles:
 


### PR DESCRIPTION
Many customers are confused about the 2 DO client settings options, thinking they have to set both to use MCC where in fact they only have to select the second option. Adding a comment to clarify this point.