### PR TITLE
Remove unsupported platform Windows Server from reusable settings ref…

### DIFF
--- a/memdocs/intune/protect/endpoint-security-firewall-policy.md
+++ b/memdocs/intune/protect/endpoint-security-firewall-policy.md
@@ -84,7 +84,7 @@ For information about configuring settings in the following profiles, see the [F
 
 In public preview, Microsoft Defender Firewall rule profiles support use of [reusable settings groups](../protect/reusable-settings-groups.md) for the following platforms:
 
-- *Windows 10, Windows 11, and Windows Server platform*
+- *Windows 10 and Windows 11*
 
 The following firewall rule profile settings are available in reusable settings groups:
 


### PR DESCRIPTION
…erence

Windows Server is unsupported for reusable settings, removing Windows Server from prereqs section after confirming with PM. Ref inc 381562858 case 2302061420001653. Also reference: hhttps://github.com/MicrosoftDocs/memdocs/pull/3770. 

Remove "Windows Server" from: https://learn.microsoft.com/en-us/mem/intune/protect/endpoint-security-firewall-policy#add-reusable-settings-groups-to-profiles-for-firewall-rules