### PR TITLE
Fix spelling in introduction-windows-365-government.md

### DIFF
--- a/windows-365/enterprise/introduction-windows-365-government.md
+++ b/windows-365/enterprise/introduction-windows-365-government.md
@@ -58,7 +58,7 @@ The following features are not yet supported for Windows 365 GCC or GCCH.
 - Resize VM
 - Citrix HDX Plus for Windows 365
 - Windows 365 app
-- Multimedia rediction for improved video playback
+- Multimedia redirection for improved video playback
 - Microsoft Dev Box
 - Convert Windows 365 licenses to higher level licenses
 


### PR DESCRIPTION
Updated a bullet point in the "Features not yet supported Windows 365 Government" section regarding multimedia redirection. The spelling of redirection was wrong and missing a few characters. Will provide more clarity and be far less confusing to those unfamiliar with multimedia redirection.