### PR TITLE
Update sql-replication.md

### DIFF
--- a/memdocs/configmgr/core/servers/manage/replication/sql-replication.md
+++ b/memdocs/configmgr/core/servers/manage/replication/sql-replication.md
@@ -46,7 +46,7 @@ WHERE UpdateTime >@cutoffTime
 
 ```sql
 SELECT * FROM ServerData
-WHERE Status = 120
+WHERE SiteStatus = 120
 ```
 
 ## Next steps


### PR DESCRIPTION
The correct column name for the SQL Server maintenance mode query is 'SiteStatus' instead of 'Status' Correct query:
SELECT * FROM ServerData
WHERE SiteStatus = 120