### PR TITLE
Add reference to prereqs link to reusable settings guidance

### DIFF
--- a/memdocs/intune/protect/endpoint-security-firewall-policy.md
+++ b/memdocs/intune/protect/endpoint-security-firewall-policy.md
@@ -95,7 +95,7 @@ When you configure a firewall rule to add one or more reusable settings groups, 
 
 Each rule you add to the profile can include both reusable settings groups and individual settings that are added directly to the rule.  However, consider using each rule for either reusable settings groups or to manage settings you add directly to the rule. This separation can help simplify future configurations or changes you might make.  
 
-For guidance on configuring reusable groups, and then adding them to this profile, see [Use reusable groups of settings with Intune policies](../protect/reusable-settings-groups.md).
+For prerequisites and guidance on configuring reusable groups, and then adding them to this profile, see [Use reusable groups of settings with Intune policies](../protect/reusable-settings-groups.md).
 
 ### Devices managed by Configuration Manager
 


### PR DESCRIPTION
Prereqs are an important note to usage of this feature, so we should add an additional emphasis here guiding towards them. --In the linked doc, we note related limitations that have led to customer confusion where we made clarifying edits. This seeks to further increase their visibility.