### PR TITLE
Update sql-performance.md

### DIFF
--- a/memdocs/configmgr/core/servers/manage/replication/sql-performance.md
+++ b/memdocs/configmgr/core/servers/manage/replication/sql-performance.md
@@ -48,8 +48,8 @@ ELSE IF @RetentionUnit = 2
 ELSE IF @RetentionUnit = 3
     SET @CTCutOffTime = DATEADD(DAY,-@RetentionPeriod,GETUTCDATE())
 
--- give a buffer of two days
-SET @CTCutOffTime = DATEADD(DAY, -2, @CTCutOffTime)
+-- give a buffer of five days
+SET @CTCutOffTime = DATEADD(DAY, -5, @CTCutOffTime)
 select top 1 @CTMinTime=commit_time from sys.dm_tran_commit_table order by commit_ts asc
 IF @CTMinTime < @CTCutOffTime
     PRINT 'there is change tracking backlog, please contact Microsoft support'


### PR DESCRIPTION
The default retention period for change tracking on MS SQL Server is 2 days, but for the configuration manager, it should always be 5 days. The places where I got this info from:
 - When installing a site server, the database auto cleanup retention period is 5 days.
 - When looking the code for the stored procedure 'spDiagChangeTracking', while gathering change tracking information we can see a comment saying that for SCCM it should always be 5 days.
 
![image](https://user-images.githubusercontent.com/40699992/235998912-b22dbd6f-f416-4b54-b914-c6050efcfb92.png)

 - While troubleshooting a change tracking issue, I've set the retention for two days, and the auto cleanup couldn't keep up.

I understand that while troubleshooting performance issues, cleaning the change tracking information up to 2 days can improve performance, however this can be misleading, since this query will always return 'there is change tracking backlog, please contact Microsoft support'. Cleaning more change tracking than default can also mask the real cause for performance issues.

Thank you!