### PR TITLE
Adds warning for hide Gaming settings

### DIFF
--- a/memdocs/intune/configuration/device-restrictions-windows-10.md
+++ b/memdocs/intune/configuration/device-restrictions-windows-10.md
@@ -220,8 +220,9 @@ These settings use the [EnterpriseCloudPrint policy CSP](/windows/client-managem
 
   - **Gaming**: **Block** prevents access to the Gaming area of the Settings app on the device. When set to **Not configured** (default), Intune doesn't change or update this setting.
 
-    [Settings/PageVisibilityList CSP](/windows/client-management/mdm/policy-csp-settings#settings-pagevisibilitylist)
-
+    > [!WARNING]
+    > On Windows 11 22H2 and later, this setting will hide the whole Notifications page under the System category of the Settings app, as it adds `ms-settings:quietmomentsgame` page to [Settings/PageVisibilityList CSP](/windows/client-management/mdm/policy-csp-settings#settings-pagevisibilitylist).
+    
   - **Ease of Access**: **Block** prevents access to the Ease of Access area of the Settings app on the device. When set to **Not configured** (default), Intune doesn't change or update this setting.
   - **Privacy**: **Block** prevents access to the Privacy area of the Settings app on the device. When set to **Not configured** (default), Intune doesn't change or update this setting.
   - **Update and Security**: **Block** prevents access to the Update & Security area of the Settings app on the device. When set to **Not configured** (default), Intune doesn't change or update this setting.

--- a/memdocs/intune/configuration/device-restrictions-windows-10.md
+++ b/memdocs/intune/configuration/device-restrictions-windows-10.md
@@ -7,7 +7,7 @@ keywords:
 author: MandiOhlinger
 ms.author: mandia
 manager: dougeby
-ms.date: 01/18/2022
+ms.date: 06/06/2023
 ms.topic: reference
 ms.service: microsoft-intune
 ms.subservice: configuration
@@ -218,10 +218,12 @@ These settings use the [EnterpriseCloudPrint policy CSP](/windows/client-managem
 
       [Settings policy CSP](/windows/client-management/mdm/policy-csp-settings)
 
-  - **Gaming**: **Block** prevents access to the Gaming area of the Settings app on the device. When set to **Not configured** (default), Intune doesn't change or update this setting.
+  - **Gaming**: When set to **Block**, this setting:
+  
+    - Prevents access to the **Settings** app > **Gaming** area on the device. 
+    - On Windows 11 22H2 and later, it hides the **Settings** app > **System** > **Notifications** area on the device. Specifically, it adds the `ms-settings:quietmomentsgame` page to the [Settings/PageVisibilityList CSP](/windows/client-management/mdm/policy-csp-settings#settings-pagevisibilitylist).
 
-    > [!WARNING]
-    > On Windows 11 22H2 and later, this setting will hide the whole Notifications page under the System category of the Settings app, as it adds `ms-settings:quietmomentsgame` page to [Settings/PageVisibilityList CSP](/windows/client-management/mdm/policy-csp-settings#settings-pagevisibilitylist).
+    When set to **Not configured** (default), Intune doesn't change or update this setting.
     
   - **Ease of Access**: **Block** prevents access to the Ease of Access area of the Settings app on the device. When set to **Not configured** (default), Intune doesn't change or update this setting.
   - **Privacy**: **Block** prevents access to the Privacy area of the Settings app on the device. When set to **Not configured** (default), Intune doesn't change or update this setting.


### PR DESCRIPTION
Warns that hiding Gaming will lead the whole Notifications settings page to be hidden on W11 22H2 and later