### PR TITLE
Updated supported OS's that can run MDE

### DIFF
--- a/memdocs/intune/protect/advanced-threat-protection.md
+++ b/memdocs/intune/protect/advanced-threat-protection.md
@@ -38,6 +38,7 @@ Microsoft Defender for Endpoint works with devices that run:
 - iOS/iPadOS
 - Windows 10
 - Windows 11
+- macOS
 
 To be successful, you'll use the following configurations in concert:
 


### PR DESCRIPTION
The following articles seem to point to that macOS is supported to run MDE:

https://docs.microsoft.com/en-us/mem/intune/protect/advanced-threat-protection-configure https://docs.microsoft.com/en-us/mem/intune/apps/apps-advanced-threat-protection-macos