### PR TITLE
Update intune-company-portal-preferences-macos.md

### DIFF
--- a/memdocs/intune/user-help/intune-company-portal-preferences-macos.md
+++ b/memdocs/intune/user-help/intune-company-portal-preferences-macos.md
@@ -39,7 +39,7 @@ Select your preferences for single sign-on and in-app data collection in Company
 
 ## Single sign-on   
 
-The single sign-on extension configures your work or school account so that you only have to authenticate once to access all apps and services within your organization's network. To opt out of SSO on your macOS device, clear the checkbox next to **Don't ask me to sign in with single sign-on for this device**. 
+The single sign-on extension configures your work or school account so that you only have to authenticate once to access all apps and services within your organization's network. To opt out of SSO on your macOS device, select the checkbox next to **Don't ask me to sign in with single sign-on for this device**. 
 
 
 ## Send usage data to Microsoft    


### PR DESCRIPTION
By default, the checkbox will be cleared, and user will be opted in for SSO. 

If user needs to opt out of SSO, they need to check the box