### PR TITLE
Update remove-certificates.md

### DIFF
--- a/memdocs/intune/protect/remove-certificates.md
+++ b/memdocs/intune/protect/remove-certificates.md
@@ -64,6 +64,9 @@ A SCEP certificate is revoked *and* removed when:
 - An administrator runs the [wipe](../remote-actions/devices-wipe.md#wipe) action.
 - An administrator runs the [retire](../remote-actions/devices-wipe.md#retire) action.
 - The device is removed from an Azure AD group.
+
+A SCEP certificate is removed when:
+
 - A certificate profile is removed from the group assignment.
 
 A SCEP certificate is revoked when:


### PR DESCRIPTION
The certificate is removed from the client but it doesn't get revoked. It does get revoked if I use the "wipe" feature on the device.

Made changes accordingly

Fixes https://github.com/MicrosoftDocs/memdocs/issues/4118