### PR TITLE
Update mde-security-integration.md

### DIFF
--- a/memdocs/intune/protect/mde-security-integration.md
+++ b/memdocs/intune/protect/mde-security-integration.md
@@ -589,6 +589,7 @@ The following security settings are pending deprecation. The Defender for Endpoi
 
 - Expedite telemetry reporting frequency (under **Endpoint Detection and Response**)
 - AllowIntrusionPreventionSystem (under **Antivirus**)
+- Tamper Protection (under **Windows Security Experience**). This setting is not pending deprecation, but is currently not supported.
 
 ### Use of security settings management on domain controllers
 


### PR DESCRIPTION
During a MSFT internal call, I learned that tamper protection is not currently supported via MDE security configuration management. I want to update the public documentation to reflect this.