### PR TITLE
Update app-wrapper-prepare-ios.md with new -dl command line

### DIFF
--- a/memdocs/intune/developer/app-wrapper-prepare-ios.md
+++ b/memdocs/intune/developer/app-wrapper-prepare-ios.md
@@ -243,6 +243,7 @@ You can use the following command line parameters with the App Wrapping Tool:
 |**-b**|(Optional) Use -b without an argument if you want the wrapped output app to have the same bundle version as the input app (not recommended). <br/><br/> Use `-b <custom bundle version>` if you want the wrapped app to have a custom CFBundleVersion. If you choose to specify a custom CFBundleVersion, it's a good idea to increment the native app's CFBundleVersion by the least significant component, like 1.0.0 -> 1.0.1. |
 |**-f**|(Optional) `<Path to a plist file specifying arguments.>` Use this flag in front of the [plist](https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/PropertyLists/Introduction/Introduction.html) file if you choose to use the plist template to specify the rest of the IntuneMAMPackager properties like -i, -o, and -p. See Use a plist to input arguments. |
 |**-dt**|(Optional) Disable collection of Microsoft Intune client telemetry.
+|**-dl**|(Optional) Disable MSAL logs from the INtune logs for applications that have integrated with MSAL and implement their own MSAL logging callback.
 
 ### Use a plist to input arguments
 
@@ -265,6 +266,7 @@ In the IntuneMAMPackager/Contents/MacOS folder, open `Parameters.plist` (a blank
 | Build String Override |String|empty| The custom CFBundleVersion of the wrapped output app|
 | Extension Provisioning Profile Paths |Array of Strings|empty| An array of extension provisioning profiles for the app.
 | Disable Telemetry |Boolean|false| Same as -dt
+| Disable MSAL Log Override |Boolean|false| Same as -dl
 
 Run the IntuneMAMPackager with the plist as the sole argument:
 


### PR DESCRIPTION
Problem: If a wrapped app implements ADAL or MSAL, they need to add the "ADALLogOverrideDisabled"=True to their IntuneMAMSettings dictionary or else we will crash setting the log callback. MSAL logging is allowed by providing an API to log info to MSAL. This can only be done once. If app is doing it and we're doing it, then app will crash.

Solution: We can provide customers of AppWrapper a command line parameter that set the ADALLogOverrideDisabled = true in the IntuneMAMSettings dictionary so that it disable logging and avoid crashing. This PR is to add public documentation for customers about this new command line.