### PR TITLE
Update compliance-use-custom-settings.md

### DIFF
--- a/memdocs/intune/protect/compliance-use-custom-settings.md
+++ b/memdocs/intune/protect/compliance-use-custom-settings.md
@@ -37,7 +37,7 @@ Expanding on Intune’s built-in device compliance options, use policies for cus
 This feature applies to:
 
 - Linux – Ubuntu Desktop, version 20.04 LTS and 22.04 LTS
-- Windows 10/11
+- Windows 10/11 (Excluding Windows 10/11 Home)
 
 Before you can add custom settings to a policy, you’ll need to prepare a JSON file, and a detection script for use with each supported platform. Both the script and JSON become part of the compliance policy. Each compliance policy supports a single script, and each script can detect multiple settings:
 


### PR DESCRIPTION
Windows 10 home will not receive the Intune Management Extension when enrolled into Intune. The Intune Management Extension is required to run custom compliance scripts.