### PR TITLE
Update filters-device-properties.md

### DIFF
--- a/memdocs/intune/fundamentals/filters-device-properties.md
+++ b/memdocs/intune/fundamentals/filters-device-properties.md
@@ -1,4 +1,4 @@
----
+Devices must be Intune enrolled to use this app property---
 # required metadata
 
 title: Supported filter device and app properties & operators in Microsoft Intune
@@ -278,7 +278,7 @@ You can use the following app properties in your managed app filter rules:
   - Android
   - iOS/iPadOS
 
-- **`deviceManagementType` (Device Management Type)**: On Intune enrolled devices, create a filter rule based on the Intune device management type. Devices must be Intune enrolled to use this app property. Select from the following values using the `-eq` and `-ne` operators: 
+- **`deviceManagementType` (Device Management Type)**: Create a filter rule based on the Intune device management type. Select from the following values using the `-eq` and `-ne` operators: 
 
   - `Unmanaged`
 


### PR DESCRIPTION
The statement "Devices must be Intune enrolled to use this app property" don't make sense and it's adding confusion to customer's reading this article. This filter property can indeed be used to filter a policy for a MAM scenario. Even the example given on how to use the property reflects this:  '(app.deviceManagementType -eq "Unmanaged")'.