### PR TITLE
Update app-wrapper-prepare-ios.md with prerequisites

### DIFF
--- a/memdocs/intune/developer/app-wrapper-prepare-ios.md
+++ b/memdocs/intune/developer/app-wrapper-prepare-ios.md
@@ -64,6 +64,11 @@ Before you run the App Wrapping Tool, you need to fulfill some general prerequis
 
 <a name='register-your-app-with-azure-ad'></a>
 
+* Make sure valid signing certificates exist in your system keychain. If you run into app code-signing issues, try the following steps to resolve:
+  * Reset trust settings for all related certificates
+  * Install intermediate certificates in the system keychain as well as login keychain
+  * Uninstall and reinstall all related certificates
+
 ## Register your app with Microsoft Entra ID
 
 1.	Register your apps with Microsoft Entra ID. For more information, see [Register an application with the Microsoft identity platform](/azure/active-directory/develop/quickstart-register-app). 

--- a/memdocs/intune/developer/app-wrapper-prepare-ios.md
+++ b/memdocs/intune/developer/app-wrapper-prepare-ios.md
@@ -64,7 +64,7 @@ Before you run the App Wrapping Tool, you need to fulfill some general prerequis
 
 <a name='register-your-app-with-azure-ad'></a>
 
-* Make sure valid signing certificates exist in your system keychain. If you run into app code-signing issues, try the following steps to resolve:
+* Make sure valid signing certificates exist in your system keychain. If you have app code-signing issues, use the following steps to resolve:
   * Reset trust settings for all related certificates
   * Install intermediate certificates in the system keychain as well as login keychain
   * Uninstall and reinstall all related certificates


### PR DESCRIPTION
From our ICM (Incident-406091722 Details - IcM (microsofticm.com)) where customers ran into code signing issue based on not having valid certs locally, we want to update our prerequisite steps for customers to self-diagnosing and self-resolve issues before reaching out to Intune oncall engineers.