### PR TITLE
Update vpn-settings-ios.md

### DIFF
--- a/memdocs/intune/configuration/vpn-settings-ios.md
+++ b/memdocs/intune/configuration/vpn-settings-ios.md
@@ -7,7 +7,7 @@ keywords:
 author: MandiOhlinger
 ms.author: mandia
 manager: dougeby
-ms.date: 06/19/2023
+ms.date: 11/15/2023
 ms.topic: reference
 ms.service: microsoft-intune
 ms.subservice: configuration
@@ -276,10 +276,7 @@ These settings apply when you choose **Connection type** > **IKEv2**.
 
 ## Automatic VPN
 
-- **Type of automatic VPN**: Select the VPN type you want to configure: On-demand VPN or per-app VPN:
-
-  > [!NOTE]
-  >  While the VPN configuration profile does not impose restrictions on editing per-app or on-demand VPN settings, only one of these settings should be utilized. Employing both simultaneously can lead to connection issues. 
+- **Type of automatic VPN**: Select the VPN type you want to configure - On-demand VPN or per-app VPN. Make sure you only use one option. Using them both simultaneously causes connection issues.
 
   - **Not configured** (default): Intune doesn't change or update this setting.
   - **On-demand VPN**: On-demand VPN uses rules to automatically connect or disconnect the VPN connection. When your devices attempt to connect to the VPN, it looks for matches in the parameters and rules you create, such as a matching domain name. If there's a match, then the action you choose runs.

--- a/memdocs/intune/configuration/vpn-settings-ios.md
+++ b/memdocs/intune/configuration/vpn-settings-ios.md
@@ -278,6 +278,9 @@ These settings apply when you choose **Connection type** > **IKEv2**.
 
 - **Type of automatic VPN**: Select the VPN type you want to configure: On-demand VPN or per-app VPN:
 
+  > [!NOTE]
+  >  While the VPN configuration profile does not impose restrictions on editing per-app or on-demand VPN settings, only one of these settings should be utilized. Employing both simultaneously can lead to connection issues. 
+
   - **Not configured** (default): Intune doesn't change or update this setting.
   - **On-demand VPN**: On-demand VPN uses rules to automatically connect or disconnect the VPN connection. When your devices attempt to connect to the VPN, it looks for matches in the parameters and rules you create, such as a matching domain name. If there's a match, then the action you choose runs.
 


### PR DESCRIPTION
Automatic VPN: iOS supports either per-app or on-demand VPN. The Intune portal allows configuring both simultaneously, leading to VPN connection issues. Adding clarification about this in the article will help IT professionals avoid encountering this problem.