### PR TITLE
Better info about which discoveries are required and two times Entra User discovery.

### DIFF
--- a/memdocs/configmgr/tenant-attach/client-details.md
+++ b/memdocs/configmgr/tenant-attach/client-details.md
@@ -30,7 +30,7 @@ The Microsoft Intune family of products is an integrated solution for managing a
 - The user accounts triggering device actions have the following prerequisites:
    - The user account needs to be a synced user object in Microsoft Entra ID (hybrid identity). This means that the user is synced to Microsoft Entra ID from Active Directory.
      - For Configuration Manager version 2103, and later: </br>
-   Has been discovered with either [Microsoft Entra user discovery](../core/servers/deploy/configure/about-discovery-methods.md#azureaddisc) or [Microsoft Entra user discovery](../core/servers/deploy/configure/about-discovery-methods.md#bkmk_aboutUser). <!--9089764-->
+   Has been discovered with [Microsoft Entra user discovery](../core/servers/deploy/configure/about-discovery-methods.md#azureaddisc) and [Active Directory user discovery](../core/servers/deploy/configure/about-discovery-methods.md#bkmk_aboutUser). <!--9089764-->
      - Starting in Configuration Manager version 2207, you can choose to implement [Intune role-based access control for tenant-attached clients](../cloud-attach/use-intune-rbac.md) to allow cloud-only users access to tenant attached clients
 
 ## Permissions


### PR DESCRIPTION
Just tested yesterday: the user must have been discovered by both Entra ID and Active Directory user discovery. Also, there was incorrectly mentioned two times: Entra User discovery when the latter one was referring to AD user discovery.