### PR TITLE
Add the info that the 64-bit registry keys are not supported by Device query

### DIFF
--- a/memdocs/analytics/device-query.md
+++ b/memdocs/analytics/device-query.md
@@ -218,6 +218,8 @@ Device query supports the following entities. To learn more about what propertie
 
 - The WindowsRegistry entity fails to return the RegistryKey for root.
 
+- The WindowsRegistry entity fails to return 64-bit shared registry keys.
+
 - The WindowsRegistry entity fails to return binary ValueData.  
 
 - If you’re querying devices that are running on Windows 10, they must be on a minimum quality version.


### PR DESCRIPTION
Added text "- The WindowsRegistry entity fails to return 64-bit shared registry keys."

MS Intune Management Extension is a 32-bit program and works only with the 32-bit related registry keys and values. This limitation should be mentioned on the MS Docs website.