### PR TITLE
Update intune-endpoints.md to include ECS and fwlink domain

### DIFF
--- a/memdocs/intune/fundamentals/intune-endpoints.md
+++ b/memdocs/intune/fundamentals/intune-endpoints.md
@@ -150,6 +150,8 @@ You'll also need FQDNs that are covered as part of Microsoft 365 Requirements. F
 |contentauthassetscdn-prodeur.azureedge.net | Organizational messages |
 |contentauthrafcontentcdn-prod.azureedge.net | Organizational messages |
 |contentauthrafcontentcdn-prodeur.azureedge.net | Organizational messages |
+|config.edge.skype.com | Feature Deployment |
+|go.microsoft.com | Endpoint discovery |
 
 
 The following tables list the ports and services that the Intune client accesses:


### PR DESCRIPTION
Updating the public lists of endpoints that Intune clients hit so as to include config.edge.skype.com and go.microsoft.com.  The former is used by clients to deliver new features.  The latter is the fwlink domain that is used to redirect traffic to other endpoints.  This control over redirection allows us to not break old clients that have static URI's baked into their bits when a URI needs to change.  Primary use cases of fwlinks in clients are around endpoint discovery and linking customers to help documents.