### PR TITLE
Update certificates-scep-configure.md

### DIFF
--- a/memdocs/intune/protect/certificates-scep-configure.md
+++ b/memdocs/intune/protect/certificates-scep-configure.md
@@ -69,6 +69,7 @@ To support SCEP, the following on-premises infrastructure must run on servers th
 - **NDES server role** – To support using the Certificate Connector for Microsoft Intune with SCEP, you must configure the Windows Server that hosts the certificate connector with the Network Device Enrollment Service (NDES) server role. The connector supports installation on Windows Server 2012 R2 or later. In a later section of this article, we guide you through [installing NDES](#set-up-ndes).
 
   - The server that hosts NDES and the connector must be domain-joined and in the same forest as your Enterprise CA.
+  - The server that hosts NDES must not be a domain controller.
   - Don't use NDES that's installed on the server that hosts the Enterprise CA. This configuration represents a security risk when the CA services internet requests, and installation of the connector isn't supported on the same server as your issuing Certification Authority (CA).
   - Internet Explorer Enhanced Security Configuration [must be disabled on the server that hosts NDES](/previous-versions/windows/it-pro/windows-server-2003/cc775800(v=ws.10)) and the Microsoft Intune Connector.
 


### PR DESCRIPTION
Added prerequisite that the server that hosts NDES cannot be a domain controller. Local users/groups cannot be edited on a domain controller, so one cannot follow a subsequent step to "add the NDES service account as a member of the local IIS_IUSR group."