### PR TITLE
Update get-cloud-pc-audit-logs-using-powershell.md

### DIFF
--- a/windows-365/enterprise/get-cloud-pc-audit-logs-using-powershell.md
+++ b/windows-365/enterprise/get-cloud-pc-audit-logs-using-powershell.md
@@ -56,7 +56,7 @@ Azure monitor's diagnostic settings let you export platform logs and metrics to 
 
 ## Use Graph API and PowerShell to retrieve audit events
 
-To get audit log events for up to seven days for your Windows 365 tenant, follow these steps:
+To get audit log events for your Windows 365 tenant, follow these steps:
 
 ### Install the SDK
 


### PR DESCRIPTION
Corrected wording to remove implied 7-day limit of Audit day retrieval using PowerShell, which is not correct as it retrieves all the logs when no limit is provided and the sample cmdlets in the page also doesn't provide any time box