### PR TITLE
Corrected the minimum firmware version for the Navigator 500

### DIFF
--- a/memdocs/intune/fundamentals/android-os-project-supported-devices.md
+++ b/memdocs/intune/fundamentals/android-os-project-supported-devices.md
@@ -52,6 +52,6 @@ Before setting up Microsoft Intune for Android Open Source Project devices, ensu
 | PICO    | PICO 4 Enterprise     | PUI 5.6.0              | AR/VR Headset  |                    |
 | Realwear| HMT-1              | 11.2                | AR/VR Headset  |                    |
 | Realwear| HMT-1Z1            | 11.2                | AR/VR Headset  |                    |
-| Realwear| Navigator500       | 11.2                | AR/VR Headset  |                    |
+| Realwear| Navigator 500      | 1.1                | AR/VR Headset  |                    |
 | Lenovo| ThinkReality VRX     | VRX_user_S766001_2310192349_kona   | AR/VR Headset  |                   |
 | DigiLens Inc.| DigiLens ARGO    | DigiOS 2068 (B1.0001.2068)            | AR/VR Headset  |                    |


### PR DESCRIPTION
As per https://support.realwear.com/knowledge/realwear-releases, the Navigator 500 firmware version starts at 1.1 and the latest is currently 1.7. 11.2 is therefore incorrect.

As per Realwear, the "Navigator 500 series devices will all run the minimum firmware requirements out of box." therefore firmware version 1.1 would be the minimum. See https://support.realwear.com/knowledge/supported-enterprise-mobility-management-providers as well.