### PR TITLE
Clarification: Remote Help license is needed for users that benefit from the service

### DIFF
--- a/memdocs/intune/fundamentals/remote-help.md
+++ b/memdocs/intune/fundamentals/remote-help.md
@@ -76,7 +76,7 @@ The Remote Help app supports the following capabilities in general across the su
 - The following general prerequisites apply to Remote Help:
 
   - [Intune subscription](../fundamentals/licenses.md)
-  - [Remote Help add on license or an Intune Suite license](intune-add-ons.md#available-add-ons) for all IT support workers (helpers) and users (sharers)
+  - [Remote Help add on license or an Intune Suite license](intune-add-ons.md#available-add-ons) for all IT support workers (helpers) and users (sharers) that are targeted to use Remote Help and benefit from the service.
   - [Supported platforms and devices](#supported-platforms-and-devices)
 
   For specific prerequisites based on the platform that you're using, go to:


### PR DESCRIPTION
This sentence clarifies that licenses are not needed for all users in the tenant but only for users that benefit from the service. This is in alignment with the internal SCIM docs.