### PR TITLE
Update accounts.md

### DIFF
--- a/memdocs/configmgr/core/plan-design/hierarchy/accounts.md
+++ b/memdocs/configmgr/core/plan-design/hierarchy/accounts.md
@@ -381,7 +381,11 @@ For more information, see [Use multicast to deploy Windows over the network](../
 
 ### Network access account
 
-Client computers use the **network access account** when they can't use their local computer account to access content on distribution points. It mostly applies to workgroup clients and computers from untrusted domains. This account is also used during OS deployment, when the computer that's installing the OS doesn't yet have a computer account on the domain.
+Client computers use the **network access account** when they can't use their local computer account to access content on distribution points. It mostly applies to workgroup clients and computers from untrusted domains.
+This account is also used during OS deployment, when the computer that's installing the OS doesn't yet have a computer account on the domain.
+
+> [!NOTE]
+> Managing clients in untrusted domains and cross-forest scenarios allows for multiple network access accounts.
 
 > [!IMPORTANT]
 > The network access account is never used as the security context to run programs, install software updates, or run task sequences. It's used only for accessing resources on the network.
@@ -429,7 +433,6 @@ The network access account is still required for the following actions (includin
 
 - Task Sequence properties setting to **Run another program first**. This setting runs a package and program from a network share before the task sequence starts. For more information, see [Task sequences properties: Advanced tab](../../../osd/deploy-use/manage-task-sequences-to-automate-tasks.md#advanced-tab).
 
-- Managing clients in untrusted domains and cross-forest scenarios allows for multiple network access accounts.
 
 ### Package access account
 


### PR DESCRIPTION
The sentence: "Managing clients in untrusted domains and cross-forest scenarios allows for multiple network access accounts." does not make any sense under section: "The network access account is still required for the following actions (including eHTTP & PKI scenarios):". Because we also state the following: "If you configure the site for HTTPS or Enhanced HTTP, a workgroup or Microsoft Entra joined client can securely access content from distribution points without the need for a network access account. This behavior includes OS deployment scenarios with a task sequence running from boot media, PXE, or the Software Center." Thats why I copied the sentence to an appropriate place.