### PR TITLE
platform-sso-macos.md: Chrome extension name updated

### DIFF
--- a/memdocs/intune/configuration/platform-sso-macos.md
+++ b/memdocs/intune/configuration/platform-sso-macos.md
@@ -67,7 +67,7 @@ This article shows you how to configure Platform SSO for macOS devices in Intune
   - Microsoft Edge
   - Google Chrome
   
-    Platform SSO requires you install and enable the [Windows Accounts extension](https://chromewebstore.google.com/detail/windows-accounts/ppnbnpeolgkicgegkbkbjmhlideopiji). You can add the app to Intune, and assign it to the devices that use Google Chrome. For more information, go to:
+    Platform SSO requires you install and enable the [Microsoft Single Sign On extension](https://chromewebstore.google.com/detail/microsoft-single-sign-on/ppnbnpeolgkicgegkbkbjmhlideopiji). You can add the app to Intune, and assign it to the devices that use Google Chrome. For more information, go to:
 
     - [Set up Chrome browser on Mac](https://support.google.com/chrome/a/answer/7550274) (opens Google's web site)
     - [Chrome Enterprise policy - ExtensionInstallForcelist](https://chromeenterprise.google/policies/?policy=ExtensionInstallForcelist) (opens Google's web site)


### PR DESCRIPTION
The Chrome extension for 'Windows Accounts' is now 'Microsoft Single Sign On'. Updated the URL and name of the extension to prevent confusion.