### PR TITLE
Update endpoint-security-account-protection-policy.md

### DIFF
--- a/memdocs/intune/protect/endpoint-security-account-protection-policy.md
+++ b/memdocs/intune/protect/endpoint-security-account-protection-policy.md
@@ -38,7 +38,7 @@ Find the endpoint security policies for Account protection under *Manage* in the
 ## Prerequisites for Account protection profiles
 
 - To support the *Account protection (preview)* profile, devices must run Windows 10 or Windows 11.
-- To support the *Local user group membership (preview)* profile, devices must run Windows 10 20H2 or later, or Windows 11.
+- To support the *Local user group membership* profile, devices must run Windows 10 20H2 or later, or Windows 11.
 
 ## Role-based access controls (RBAC)
 


### PR DESCRIPTION
Hi.

I'd like to confirm any function is preview or GA. About this doc,under "Prerequisites for Account protection profiles",it shows   "Local user group membership"  is as preview function. But there is no word"preview" about  "Local user group membership"  on both ①"Account protection profiles" part and ②Microsoft Intune Admin center.

So could you please delete the word "preview" for Local user group membership"  under "Prerequisites for Account protection profiles" of the docs？