### PR TITLE
Update apps-supported-intune-apps.md

### DIFF
--- a/memdocs/intune/apps/apps-supported-intune-apps.md
+++ b/memdocs/intune/apps/apps-supported-intune-apps.md
@@ -99,8 +99,8 @@ The below apps support the Core Intune App Protection Policy settings and are al
 |Microsoft To-Do|[iOS](https://apps.apple.com/us/app/microsoft-to-do/id1212616790)|✔|No settings|✖|N/A|✖|✖|N/A|
 |Microsoft Word|[Android](https://play.google.com/store/apps/details?id=com.microsoft.office.word)|✔|No settings|✔|N/A|✖|✖|✔|
 |Microsoft Word|[iOS](https://apps.apple.com/us/app/microsoft-word/id586447913)|✔|No settings|✔|N/A|✖|✖|✔|
-|Microsoft Viva Engage|[Android](https://play.google.com/store/apps/details?id=com.yammer.v1)|✔|No settings|✖|N/A|✖|✖|N/A|
-|Microsoft Viva Engage|[iOS](https://apps.apple.com/us/app/yammer/id289559439)|✔|No settings|✖|N/A|✖|✖|N/A|
+|Microsoft Viva Engage|[Android](https://play.google.com/store/apps/details?id=com.yammer.v1)|✔|No settings|✖|N/A|✔|✖|N/A|
+|Microsoft Viva Engage|[iOS](https://apps.apple.com/us/app/yammer/id289559439)|✔|No settings|✖|N/A|✔|✖|N/A|
 
 The below apps support the core Intune App Protection Policy settings.
 


### PR DESCRIPTION
Change made on behalf of Evelyn Chan (echan@microsoft.com), Viva Engage PM: 

Org allowed accounts is now available on Viva Engage iOS and Android, the table under "Microsoft apps" on https://learn.microsoft.com/en-us/mem/intune/apps/apps-supported-intune-apps#core-app-settings needs to be updated to reflect that, in the "Org allowed accounts" column - the X's should be updated to be checkmarks.