### PR TITLE
Updated certificate authentication note

### DIFF
--- a/autopilot/requirements.md
+++ b/autopilot/requirements.md
@@ -105,7 +105,7 @@ Additional configuration might be required to grant access to required services 
 
 > [!NOTE]
 >
-> Smart card and certificate based authentication isn't supported during the out-of-box experience (OOBE). For more information, see [Smartcards and certificate-based authentication](/azure/active-directory/devices/azureadjoin-plan#smartcards-and-certificate-based-authentication).
+> During the out-of-box experience (OOBE), certificate authentication is supported when using the Microsoft Entra Certificate Based Authentication (CBA). For more information, see [Windows smart card sign-in using Microsoft Entra certificate-based authentication](/entra/identity/authentication/concept-certificate-based-authentication-smartcard).
 
 #### Service requirements
 


### PR DESCRIPTION
Updated the note on this page for the OOBE and certificate authentication. I have supported several customers with this capability. There have been inquiries about this from both customer and colleagues and I thought I could help and update a small part. 

My understanding is that this is now supported when using CBA, correct? my concern is it directly conflicts with [this doc](https://learn.microsoft.com/en-us/entra/identity/authentication/concept-certificate-based-authentication-smartcard#windows-out-of-the-box-experience-oobe. ); which I also linked it to. 

Thanks!