### PR TITLE
Update supported client OS's - Windows Server IoT 2019 for Storage and Windows Server IoT 2022 for Storage  are not supported client OSs

### DIFF
--- a/memdocs/configmgr/core/plan-design/configs/supported-operating-systems-for-clients-and-devices.md
+++ b/memdocs/configmgr/core/plan-design/configs/supported-operating-systems-for-clients-and-devices.md
@@ -67,8 +67,10 @@ For more information, see the following articles:
 ### Supported server OS versions
 
 - **Windows Server 2022**: IoT, Standard, Datacenter (_starting in Configuration Manager version 2107_)<!-- 10200029 -->
+    - *Windows Server IoT 2022 for Storage* is not supported
 
-- **Windows Server 2019**: IoT, Standard, Datacenter 
+- **Windows Server 2019**: IoT, Standard, Datacenter
+    - *Windows Server IoT 2019 for Storage* is not supported
 
 - **Windows Server 2016**: Standard, Datacenter 
 


### PR DESCRIPTION
Windows Server IoT 2019 for Storage and Windows Server IoT 2022 for Storage are vendor-specific versions of Windows IoT, and can't be tested. 

I'm adding explicit entries that they are not supported, but if there is a better way to call this out in the documentation, please suggest.