### PR TITLE
Adding notes to corporate identifier

### DIFF
--- a/autopilot/device-preparation/overview.md
+++ b/autopilot/device-preparation/overview.md
@@ -140,6 +140,11 @@ Windows Autopilot device preparation supports the Intune corporate identifier en
 - [What are enrollment restrictions?](/mem/intune/enrollment/enrollment-restrictions-set).
 - [Create device platform restrictions](/mem/intune/enrollment/create-device-platform-restrictions).
 
+> [!NOTE]
+>
+> This step is mandatory if your environment prohibits the enrollment of personal Windows devices.
+
+
 ## Tutorial
 
 For tutorials with detailed instructions on configuring Windows Autopilot device preparation, see [Windows Autopilot device preparation scenarios](tutorial/scenarios.md).


### PR DESCRIPTION
Below sentence in the corporate identifier passage confuses the user who blocks personal windows device enrollment in their tenant. Hence adding notes.

===========
 Corporate identifiers for Windows is optional for Windows Autopilot device preparation. Corporate identifiers for Windows isn't required for a Windows Autopilot device preparation deployment to work. 
===========