### PR TITLE
Windows 365 Guided boot scenario

### DIFF
--- a/windows-365/enterprise/windows-365-boot-guide.md
+++ b/windows-365/enterprise/windows-365-boot-guide.md
@@ -45,6 +45,7 @@ For more information about guided scenarios in general, see [Intune guided scena
 ## Prerequisites
 
 - Each physical device and Cloud PC must be running Windows 11 Enterprise or Professional, version 22621.3374 or later.
+- A Windows 365 Enterprise license is required to make Windows 365 Boot provisioning policies. 
 - You must have the Intune Service Administrator role.
 
 Before adding physical devices to the group, you must ensure that they meet the [Windows 365 Boot requirements](windows-365-boot-physical-device-requirements.md).


### PR DESCRIPTION
The Windows 365 guided boot scenario guides users through a provisioning policy within the Windows 365 pane under Devices > Device onboarding in Microsoft Intune.

This panel is only available to Windows 365 Enterprise licensed tenants. Users with a Windows 365 Business license will need to leverage configuration profiles to configure Windows 365 Boot.