### PR TITLE
Update managed-software-updates-ios-macos.md

### DIFF
--- a/memdocs/intune-service/protect/managed-software-updates-ios-macos.md
+++ b/memdocs/intune-service/protect/managed-software-updates-ios-macos.md
@@ -73,6 +73,10 @@ Use the following information to help you decide which policy type to use.
 | macOS | ✅ | ❌ |
 | &nbsp;|&nbsp; | &nbsp;|
 | **Auto deploy latest update** | &nbsp; | &nbsp; |
+| iOS/iPadOS | 18.0+ | ✅ |
+| macOS | ❌ | ✅ |
+| &nbsp;|&nbsp; | &nbsp;|
+| **Configure Update Window** | &nbsp; | &nbsp; |
 | iOS/iPadOS | ❌ | ✅ |
 | macOS | ❌ | ✅ |
 | &nbsp;|&nbsp; | &nbsp;|
@@ -185,7 +189,7 @@ When you configure managed software updates, you might want to manage aspects of
 
 - Control whether users are allowed to update to the latest major update, latest minor update, or are offered both.
 
-Previously in MDM, these settings were spread across multiple payloads such as Restrictions, Managed Settings, and Software Update. As of August 2024, it's recommended to use the DDM-based Software Update Settings configuration to manage updates. To create a Software Update Settings policy, go to the Settings catalog > Declarative Device Management (DDM) > Software Update Settings. More information on these settings is available in the documentation section for the [Software Update Settings declarative configuration](/mem/intune-service/configuration/apple-settings-catalog-configurations).
+Previously in MDM, these settings were spread across multiple payloads such as Restrictions, Managed Settings, and Software Update. As of August 2024, it's recommended to use the DDM-based Software Update Settings configuration to manage updates. To create a Software Update Settings policy, go to the Settings catalog > Declarative Device Management (DDM) > Software Update Settings. Software Update Settings contains controls regarding the recurring update process, whereas Software Update contains controls to force an update.
 
 ## Delay visibility of updates using MDM
 


### PR DESCRIPTION
This graph indicates that Managed Software Updates cannot force automatic update with latest version - but isn't this what the "Software Update Settings - Automatic Options" do? It allows specifically setting Automatic updates to Always on. The tooltip basically describes forcing automatic update to latest version... Assuming the graph is deprecated.

What you CAN'T do, from what I can tell, is configure automatic update time periods - so I added that. 

Removed the line saying "More information on these settings is available in the documentation section for the Software Update Settings declarative configuration." because it's not - that link just brings you to a barebones overall Apple Device Config item list, which has nothing but links to Apple documentation. Frankly I get really frustrated with how many different tabs always end up open when I try to read Microsoft documentation, so I just replaced it with a summary of what these do instead of another link for people to open, lose track of, and feel frustrated about. 

Hope these help