### PR TITLE
Update microsoft-intune-app-linux.md to add information for Fedora 42

### DIFF
--- a/intune/intune-service/user-help/microsoft-intune-app-linux.md
+++ b/intune/intune-service/user-help/microsoft-intune-app-linux.md
@@ -152,3 +152,14 @@ Run the following commands to uninstall the Microsoft Intune app and remove loca
    sudo rm -rf /etc/opt/microsoft/mdatp
    sudo rm -rf /opt/microsoft/mdatp
    ```  
+### Install Microsoft Intune app for Fedora 42 and above
+
+Prior to Fedora 42, the above instructions for RedHat Enterprise Linux could be used to install Microsoft Intune on Fedora Linux.
+
+As of Fedora 42, the java-11-openjdk package has been deprecated and Fedora recomends using the [adoptium-temurin-java-repository](https://fedoraproject.org/wiki/Changes/ThirdPartyLegacyJdks#adoptium-temurin-java-repository) instead to provide the required java package for microsoft-intune.
+
+1. Enable the adoptium-temurin-java-repository
+    ```bash
+    sudo dnf install  adoptium-temurin-java-repository
+    ```
+2. Continue installing using the RedHat Enterprise Linux instructions.


### PR DESCRIPTION
Fedora 42 no longer supports java-11-openjdk from the standard repositories. Updated instructions to provide information on how to install on Fedora 42 and above.

I'm not sure if this matters to the official documentation as Fedora isn't supported officially, but the below helped me upgrade from Fedora 41 to 42 while keeping the java jdk installed. 