### PR TITLE
Update platform-sso-macos.md to clarify FileVault policy setting

### DIFF
--- a/intune/intune-service/configuration/platform-sso-macos.md
+++ b/intune/intune-service/configuration/platform-sso-macos.md
@@ -3,7 +3,6 @@ title: Configure Platform SSO for macOS devices
 description: Use Microsoft Intune to configure Platform SSO and deploy the configuration to your macOS devices. Platform SSO enables single sign-on (SSO) using Microsoft Entra ID with the Secure Enclave, smart card, or password authentication methods. You create a settings catalog policy to configure the settings. This article is a step-by-step guide to configure Platform SSO for macOS devices using Intune.
 author: MandiOhlinger
 ms.author: mandia
-manager: laurawi
 ms.date: 11/24/2025
 ms.topic: how-to
 appliesto:


### PR DESCRIPTION
Line 232 needs clarification that this setting only applies when the authentication method is set to "Password".

In Intune, when hovering over the "i" icon beside the "FileVault Policy" setting, you are told: **The policy to apply when using Platform SSO at FileVault unlock on Apple Silicon Macs. Applies when 'AuthenticationMethod' is `Password`.**