### PR TITLE
Add UUP-related description to Dynamic Update setting

### DIFF
--- a/intune/configmgr/core/clients/deploy/about-client-settings.md
+++ b/intune/configmgr/core/clients/deploy/about-client-settings.md
@@ -976,6 +976,8 @@ When you set this option to **Yes**, it sets the policy for **Allow signed updat
 <!--4062619-->
 Use this setting to configure [Dynamic Update for Windows](https://techcommunity.microsoft.com/t5/Windows-IT-Pro-Blog/The-benefits-of-Windows-10-Dynamic-Update/ba-p/467847). Dynamic Update installs language packs, features on demand, drivers, and cumulative updates during Windows setup by directing the client to download these updates from the internet. When this setting is set to either **Yes** or **No**, Configuration Manager modifies the [setupconfig](/windows-hardware/manufacture/desktop/windows-setup-command-line-options) file that is used during feature update installation.
 
+For UUP-based feature updates, this setting does not control Dynamic Update excluding drivers, because the only applicable Dynamic Update parameter is /DynamicUpdate NoDrivers in setupconfig.
+
 - **Not Configured** - The default value. No changes are made to the setupconfig file.
   - Dynamic Update is enabled by default on all supported versions of Windows 10 or later.
     - For Windows 10, version 1803 and earlier, Dynamic Update checks the device's WSUS server for approved dynamic updates. In Configuration Manager environments, dynamic updates are never directly approved in the WSUS server so these devices don't install them.


### PR DESCRIPTION
As described at below document, this option which modify the setupconfig no longer enable Dynamic Update for UUP-based feature updates.
To avoid confusion and unrealistic expectations, the behavior related to UUP should be explained clearly.

https://techcommunity.microsoft.com/discussions/windows-servicing/faq-wsus-and-unified-update-platform-uup-on-premises/3773235