### PR TITLE
Add Firefox to list of supported Platform SSO browsers

### DIFF
--- a/intune/intune-service/configuration/platform-sso-macos.md
+++ b/intune/intune-service/configuration/platform-sso-macos.md
@@ -64,6 +64,12 @@ You configure Platform SSO using the Intune [settings catalog](settings-catalog.
 
   - Safari
 
+  - Firefox
+
+    Configure the MicrosoftEntraSSO policy for browser integration
+
+    See: [Firefox policy templates](https://mozilla.github.io/policy-templates/#microsoftentrasso) and [Firefox Enterprise 133 release notes](https://support.mozilla.org/en-US/kb/firefox-enterprise-133-release-notes)
+
   You can use Intune to add web browser apps, including [package (`.pkg`)](../apps/lob-apps-macos.md) and [disk image (`.dmg`)](../apps/lob-apps-macos-dmg.md) files, and deploy the app to your macOS devices. To get started, go to [Add apps to Microsoft Intune](../apps/apps-add.md).
 
 - Platform SSO uses the Intune settings catalog to configure the required settings. To create the settings catalog policy, at a minimum, sign in to the [Microsoft Intune admin center](https://go.microsoft.com/fwlink/?linkid=2109431) with an account that has the following Intune permissions:

--- a/intune/intune-service/configuration/platform-sso-macos.md
+++ b/intune/intune-service/configuration/platform-sso-macos.md
@@ -3,7 +3,7 @@ title: Configure Platform SSO for macOS devices
 description: Use Microsoft Intune to configure Platform SSO and deploy the configuration to your macOS devices. Platform SSO enables single sign-on (SSO) using Microsoft Entra ID with the Secure Enclave, smart card, or password authentication methods. You create a settings catalog policy to configure the settings. This article is a step-by-step guide to configure Platform SSO for macOS devices using Intune.
 author: MandiOhlinger
 ms.author: mandia
-ms.date: 11/24/2025
+ms.date: 03/26/2026
 ms.topic: how-to
 appliesto:
 - ✅ macOS
@@ -63,12 +63,7 @@ You configure Platform SSO using the Intune [settings catalog](settings-catalog.
     > There are sample `.plist` files at [ManagedPreferencesApplications examples on GitHub](https://github.com/ProfileCreator/ProfileManifests/tree/master/Manifests/ManagedPreferencesApplications). This GitHub repository is not owned, not maintained, and not created by Microsoft. Use the information at your own risk.
 
   - Safari
-
-  - Firefox
-
-    Configure the MicrosoftEntraSSO policy for browser integration
-
-    See: [Firefox policy templates](https://mozilla.github.io/policy-templates/#microsoftentrasso) and [Firefox Enterprise 133 release notes](https://support.mozilla.org/en-US/kb/firefox-enterprise-133-release-notes)
+  - Firefox - Configure the [MicrosoftEntraSSO policy](https://mozilla.github.io/policy-templates/#microsoftentrasso) (opens Mozilla's web site).
 
   You can use Intune to add web browser apps, including [package (`.pkg`)](../apps/lob-apps-macos.md) and [disk image (`.dmg`)](../apps/lob-apps-macos-dmg.md) files, and deploy the app to your macOS devices. To get started, go to [Add apps to Microsoft Intune](../apps/apps-add.md).
 
@@ -356,7 +351,7 @@ When you configure Platform SSO, you might see the following errors:
 ## Related articles
 
 - [Common Platform SSO scenarios for macOS devices](platform-sso-scenarios.md)
-- [macOS Platform Single Sign-on overview (preview)](/entra/identity/devices/macos-psso)
+- [macOS Platform Single Sign-on overview](/entra/identity/devices/macos-psso)
 - [Microsoft Enterprise SSO plug-in](/entra/identity-platform/apple-sso-plugin)
 - [Use the Microsoft Enterprise SSO app extension on macOS devices](use-enterprise-sso-plug-in-macos-with-intune.md)
 - [What is a Primary Refresh Token (PRT)?](/entra/identity/devices/concept-primary-refresh-token)


### PR DESCRIPTION
According to the following Microsoft resources, Firefox supports Platform SSO:
- https://techcommunity.microsoft.com/blog/microsoft-entra-blog/now-generally-available-platform-sso-for-macos-with-microsoft-entra-id/4437424
- https://learn.microsoft.com/en-us/entra/identity-platform/apple-sso-plugin (blame shows that the change was made in August 2025: https://github.com/MicrosoftDocs/entra-docs/commit/a160828a362b3d18e633e576daf8bae032657a6e) 

There are also non-Microsoft sources that confirm this:
- Firefox 133 release notes: https://support.mozilla.org/en-US/kb/firefox-enterprise-133-release-notes
- https://mozilla.github.io/policy-templates/#microsoftentrasso

Lastly, there are non-official guides that show how to configure it:
- https://www.intunemacadmins.com/platform-single-sign-on/browser_sso/
- many success stories on Reddit 

Companies make the call to provide support for specific browsers on workstations based on the contents of this page, but if I'm reading it right, the page is out of date. Apologies in advance if I missed any subtlety between Enterprise SSO, Platform SSO and app extensions, that might render this PR incorrect.