### PR TITLE
docs: Add Zebra-only limitation note for Android Battery properties

### DIFF
--- a/intune/advanced-analytics/ref-data-platform-schema.md
+++ b/intune/advanced-analytics/ref-data-platform-schema.md
@@ -87,6 +87,9 @@ For entities that include Android data, the following platforms are supported:
 | `Model`| String | Display name of the battery.|Windows|
 | `SerialNumber`| String | The battery serial number that the manufacturer assigned.|Android|
 
+> [!NOTE]
+> On Android, the following Battery properties are only available on **Zebra devices**: `CycleCount`, `Health`, `InstanceName`, and `SerialNumber`.
+
 ## `BiosInfo`
 
 > **Description**: Provides basic BIOS information.\

--- a/intune/advanced-analytics/ref-data-platform-schema.md
+++ b/intune/advanced-analytics/ref-data-platform-schema.md
@@ -88,7 +88,7 @@ For entities that include Android data, the following platforms are supported:
 | `SerialNumber`| String | The battery serial number that the manufacturer assigned.|Android|
 
 > [!NOTE]
-> On Android, the following Battery properties are only available on **Zebra devices**: `CycleCount`, `Health`, `InstanceName`, and `SerialNumber`.
+> On Android, the following Battery properties are available only on Zebra devices: `CycleCount`, `Health`, `InstanceName`, and `SerialNumber`.
 
 ## `BiosInfo`
 


### PR DESCRIPTION
## Summary
Adds a note to the Battery entity documentation clarifying that on Android, Battery properties are only available on **Zebra devices**.

## Changes
Added a NOTE block after the Battery table:

> On Android, the following Battery properties are only available on **Zebra devices**: \CycleCount\, \Health\, \InstanceName\, and \SerialNumber\.

## Why
The underlying implementation queries Zebra-specific battery statistics, so these properties won't return data on other Android OEMs (Samsung, Google Pixel, etc.).