### PR TITLE
Remove access policies entry

### DIFF
--- a/intune/fundamentals/role-based-access-control/multi-admin-approval.md
+++ b/intune/fundamentals/role-based-access-control/multi-admin-approval.md
@@ -27,7 +27,6 @@ Intune supports access policies for the following resources:
 - Device actions - Applies to [wipe](../../device-management/actions/wipe.md), [retire](../../device-management/actions/retire.md), and [delete](../../device-management/actions/delete.md) device actions.
 - Role-based access control – Applies to changes to roles, including modifications to role permissions, admin groups, or member group assignments.
 - Scripts – Applies to deploying scripts to devices that run [Windows](../../device-management/tools/run-powershell-scripts-windows.md).
-- Access Policies - Applies to creating or managing multiple administrative approval policies.
 - Tenant Configuration - Applies to managing [device categories](../../device-management/create-device-categories.md), including creating, editing, or deleting them.
 
 ## Prerequisites for access policies and approvers

--- a/intune/fundamentals/role-based-access-control/multi-admin-approval.md
+++ b/intune/fundamentals/role-based-access-control/multi-admin-approval.md
@@ -29,6 +29,8 @@ Intune supports access policies for the following resources:
 - Scripts – Applies to deploying scripts to devices that run [Windows](../../device-management/tools/run-powershell-scripts-windows.md).
 - Tenant Configuration - Applies to managing [device categories](../../device-management/create-device-categories.md), including creating, editing, or deleting them.
 
+Changes to access policies require a second administrator's approval. Because this resource type is automatically protected, it isn't available as a selectable profile type when you create an access policy.
+
 ## Prerequisites for access policies and approvers
 
 To use Multi Admin Approval, your tenant must have at least two administrator accounts. The MAA workflow has three distinct roles, each with different permission requirements:
@@ -178,4 +180,4 @@ You can cancel a request before it's approved by selecting it from the **My requ
 
 ## Related content
 
-Manage [role-based access control](../role-based-access-control/overview.md)
+- Manage [role-based access control](../role-based-access-control/overview.md)


### PR DESCRIPTION
## Documentation issue

The article says that **Access Policies** is a supported resource type for Multi Admin Approval:

https://github.com/MicrosoftDocs/memdocs/blob/main/intune/fundamentals/role-based-access-control/multi-admin-approval.md?plain=1#L30

Specifically, line 30 states:

> Access Policies - Applies to creating or managing multiple administrative approval policies.

## Observed behavior

In my tenant (Service release 2604), when I go to create a Multi Admin Approval access policy, I do **not** see **Access Policies** as an available **Profile type** / resource to protect.
<img width="817" height="696" alt="image" src="https://github.com/user-attachments/assets/258f1183-cb69-4971-8145-23e2d454364c" />

## Request

Please clarify one of the following in the documentation:

- whether **Access Policies** is still in rollout / preview / tenant-dependent availability, or
- whether the article is incorrect and this resource type is not generally available, or
- what prerequisites are required for it to appear.

## Suggested doc improvement

If this feature is not universally available, please add a note near the supported resource list indicating that the available resource types can vary by tenant and rollout status.