### PR TITLE
Update ODBC redistributable version requirement

### DIFF
--- a/intune/configmgr/core/plan-design/changes/whats-new-in-version-2509.md
+++ b/intune/configmgr/core/plan-design/changes/whats-new-in-version-2509.md
@@ -62,7 +62,7 @@ The Service Connection Tool (SCT) is improved to provide better logging and erro
 
 ### Microsoft ODBC redistributable
 - The Microsoft ODBC redistributable component is updated to version **18.4.1.1** on all Site servers and Management Points.
- - ConfigMgrPreReq throws an error stalling the upgrade if it detects a version lower than 18.4.4.1.
+ - ConfigMgrPreReq throws an error stalling the upgrade if it detects a version lower than 18.4.1.1.
     
     > INFO: Microsoft ODBC Driver 18 for SQL Server is installed but it is older than the required version.  
     > SQL client prerequisite missing for Configuration Manager setup.;    Error;    Install the Microsoft ODBC driver 18 for SQL setup from https://go.microsoft.com/fwlink/?linkid=2299909. More information https://go.microsoft.com/fwlink/?linkid=2226618

--- a/intune/configmgr/core/plan-design/changes/whats-new-in-version-2509.md
+++ b/intune/configmgr/core/plan-design/changes/whats-new-in-version-2509.md
@@ -62,7 +62,7 @@ The Service Connection Tool (SCT) is improved to provide better logging and erro
 
 ### Microsoft ODBC redistributable
 - The Microsoft ODBC redistributable component is updated to version **18.4.1.1** on all Site servers and Management Points.
- - ConfigMgrPreReq throws an error stalling the upgrade if it detects a version lower than 18.4.1.1.
+- Prerequisite check throws an error stalling the upgrade if it detects a version lower than 18.4.1.1.
     
     > INFO: Microsoft ODBC Driver 18 for SQL Server is installed but it is older than the required version.  
     > SQL client prerequisite missing for Configuration Manager setup.;    Error;    Install the Microsoft ODBC driver 18 for SQL setup from https://go.microsoft.com/fwlink/?linkid=2299909. More information https://go.microsoft.com/fwlink/?linkid=2226618


### PR DESCRIPTION
Updated the minimum required version for Microsoft ODBC redistributable from 18.4.4.1 to 18.4.1.1 in the upgrade notes.

The upgrade notes mention ODBC Redistributable version 18.4.4.1, but this version does not seem to exist. It may be a typo for 18.4.1.1.
https://learn.microsoft.com/en-us/sql/connect/odbc/windows/release-notes-odbc-sql-server-windows?view=sql-server-ver17#184