### PR TITLE
Update configure-precache-content.md

### DIFF
--- a/intune/configmgr/osd/deploy-use/configure-precache-content.md
+++ b/intune/configmgr/osd/deploy-use/configure-precache-content.md
@@ -103,7 +103,7 @@ For example, the following **Upgrade OS** step uses the English version:
 - On the **Distribution Points** tab, configure the **Deployment options** settings. If the content isn't pre-cached before a user starts the installation, the client uses these settings.
 
     > [!IMPORTANT]
-    > For a task sequence that installs an OS image, don't use the deployment option to **Download content locally when needed by the running task sequence**. When the task sequence wipes the disk before it applies the OS image, it removes the client cache. Since the content is gone, the task sequence fails.<!-- SCCMDocs-PR #1338 --> These deployment options are dynamic based on other options you select for the deployment. For more information, see [Deploy a task sequence](deploy-a-task-sequence.md#bkmk_deploy-options).<!-- MEMDocs#328, SCCMDocs#2114 -->
+    > For a task sequence that installs an OS image, don't use the deployment option to **Download all content locally before starting task sequence**. When the task sequence wipes the disk before it applies the OS image, it removes the client cache. Since the content is gone, the task sequence fails.<!-- SCCMDocs-PR #1338 --> These deployment options are dynamic based on other options you select for the deployment. For more information, see [Deploy a task sequence](deploy-a-task-sequence.md#bkmk_deploy-options).<!-- MEMDocs#328, SCCMDocs#2114 -->
 
 ## User experience
 


### PR DESCRIPTION
Are you sure that is not mis in this part ? 

> _For a task sequence that installs an OS image, don't use the deployment option to **Download content locally when needed by the running task sequence**. When the task sequence wipes the disk before it applies the OS image, it removes the client cache. Since the content is gone, the task sequence fails._

In my opinion must be : 

> For a task sequence that installs an OS image, don't use the deployment option to **Download all content locally before starting task sequence**.....

Because in this case client download all content, then disk will be wipe and TS failed.

In short need to replace  "Download content locally when needed by the running task sequence" on "Download all content locally before starting task sequence"

Am I right ? :)